### PR TITLE
Trigger CI workflow on PRs targeting main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
     tags: ["v*.*.*"]
   pull_request:
+    branches: [main]
   schedule:
-    - cron: '0 0 * * 3' # 00:00 every Wednesday
+    - cron: "0 0 * * 3" # 00:00 every Wednesday
+  workflow_dispatch:
 
 defaults:
   run:
@@ -39,7 +41,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18.3'
+          go-version: "1.18.3"
 
       - name: Build yardl binaries for multiple platforms
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
Addresses [this](https://github.com/microsoft/yardl/actions/runs/3570569789) warning:
<img width="759" alt="image" src="https://user-images.githubusercontent.com/339432/204513572-052255e1-d80b-432c-9bce-6f905cd78e50.png">

We don't want to run the workflow on pushes to any branch, so we will instead allow the workflow to be triggered manually.
