### PR TITLE
Add std::remove(file) to sample and smoketest

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -170,6 +170,7 @@ create `playground.cc` that looks like this:
 
 int main() {
   std::string filename = "playground.bin";
+  std::remove(filename.c_str());
 
   {
     playground::binary::MyProtocolWriter writer(filename);
@@ -246,6 +247,7 @@ HDF5 file. This requires only a few modifications to our code:
   int main() {
 -   std::string filename = "playground.bin";
 +   std::string filename = "playground.h5";
+    std::remove(filename.c_str());
 
     {
 -      playground::binary::MyProtocolWriter writer(filename);

--- a/smoketest/cpp/smoketest.cc
+++ b/smoketest/cpp/smoketest.cc
@@ -1,10 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include <iostream>
+
 #include "generated/hdf5/protocols.h"
 
 int main() {
-  smoketest::hdf5::MyProtocolWriter w("smoketest.h5");
+  std::string filename = "smoketest.h5";
+  std::remove(filename.c_str());
+
+  smoketest::hdf5::MyProtocolWriter w(filename);
 
   w.WriteHeader({"123"});
 


### PR DESCRIPTION
Running the sample more than once would throw an error because the HDF5 file already exists.