### PR TITLE
Require array access index arguments to be given in order

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -588,7 +588,7 @@ MyRec: !record
   computedFields:
     accessArray: arrayField
     accessArrayElement: arrayField[0, 1]
-    accessArrayElementByName: arrayField[y:1, x:0]
+    accessArrayElementByName: arrayField[x:0, y:1]
     sizeOfArrayField: size(arrayField)
     sizeOfFirstDimension: size(arrayField, 0)
     sizeOfXDimension: size(arrayField, 'x')

--- a/models/test/unittests.yml
+++ b/models/test/unittests.yml
@@ -465,7 +465,7 @@ RecordWithComputedFields: !record
     accessNestedTupleField: tupleField.v2
     accessArrayField: arrayField
     accessArrayFieldElement: arrayField[0, 1]
-    accessArrayFieldElementByName: arrayField[y:1, x:0]
+    accessArrayFieldElementByName: arrayField[x:0, y:1]
     accessVectorField: vectorField
     accessVectorFieldElement: vectorField[1]
     accessVectorOfVectorsField: vectorOfVectorsField[1][2]

--- a/tooling/pkg/dsl/validation_computed_fields.go
+++ b/tooling/pkg/dsl/validation_computed_fields.go
@@ -220,17 +220,26 @@ func resolveComputedFields(env *Environment, errorSink *validation.ErrorSink) *E
 
 					if labeledCount > 0 {
 						orderedArguments := make([]*IndexArgument, len(*d.Dimensions))
-						for _, arg := range t.Arguments {
+						for argIndex, arg := range t.Arguments {
 							found := false
-							for i, dim := range *d.Dimensions {
+							for dimIndex, dim := range *d.Dimensions {
 								if *dim.Name == arg.Label {
 									found = true
-									if orderedArguments[i] != nil {
+									if orderedArguments[dimIndex] != nil {
 										errorSink.Add(validationError(arg.Value, "array index has multiple arguments for dimension '%s'", *dim.Name))
 										return t
 									}
 
-									orderedArguments[i] = arg
+									if dimIndex != argIndex {
+										expectedOrder := make([]string, len(*d.Dimensions))
+										for i, dim := range *d.Dimensions {
+											expectedOrder[i] = *dim.Name
+										}
+										errorSink.Add(validationError(arg.Value, "array index has arguments must be specified in order: %s", strings.Join(expectedOrder, ", ")))
+										return t
+									}
+
+									orderedArguments[dimIndex] = arg
 									break
 								}
 							}

--- a/tooling/pkg/dsl/validation_computed_fields_test.go
+++ b/tooling/pkg/dsl/validation_computed_fields_test.go
@@ -218,7 +218,7 @@ X: !record
         y:
   computedFields:
     y1: y[1, 2]
-    y2: y[y:2, x:1]`
+    y2: y[x:1, y:2]`
 	_, err := parseAndValidate(t, src)
 	assert.Nil(t, err)
 }
@@ -251,6 +251,21 @@ X: !record
     y2: y[x:1, x:1]`
 	_, err := parseAndValidate(t, src)
 	assert.ErrorContains(t, err, `array index has multiple arguments for dimension 'x'`)
+}
+
+func TestIndexArrayDimensionsOutOfOrder(t *testing.T) {
+	src := `
+X: !record
+  fields:
+    y: !array
+      items: int
+      dimensions:
+        x:
+        y:
+  computedFields:
+    y2: y[y:1, x:1]`
+	_, err := parseAndValidate(t, src)
+	assert.ErrorContains(t, err, `array index has arguments must be specified in order`)
 }
 
 func TestIndexArrayInvalidDimensionName(t *testing.T) {
@@ -319,7 +334,7 @@ X: !record
         x: 10
         y: 20
   computedFields:
-    y1: y[y:1,x:10]`
+    y1: y[x:10, y:1]`
 	_, err := parseAndValidate(t, src)
 	assert.ErrorContains(t, err, `index argument (10) is too large for array dimension 'x' of length 10`)
 }


### PR DESCRIPTION
Based on feedback, we now require array access index arguments to be given in the correct order, even when dimension names are used. 

For example, this would no longer be valid:

```yaml
MyRec: !record
  fields:
    arrayField: !array
        items: int
        dimensions: [x, y]
  computedFields:
    accessArrayElementByName: arrayField[y:1, x:0]
```

Note that the `x` and `y` arguments are provided out of order. You will now have to write `arrayField[x:0, y:1]`

Addresses #20 