### PR TITLE
Fix enums with `size` as base type

### DIFF
--- a/cpp/test/generated/binary/protocols.cc
+++ b/cpp/test/generated/binary/protocols.cc
@@ -2180,6 +2180,10 @@ void EnumsWriter::WriteVecImpl(std::vector<test_model::Fruits> const& value) {
   yardl::binary::WriteVector<test_model::Fruits, yardl::binary::WriteEnum<test_model::Fruits>>(stream_, value);
 }
 
+void EnumsWriter::WriteSizeImpl(test_model::SizeBasedEnum const& value) {
+  yardl::binary::WriteEnum<test_model::SizeBasedEnum>(stream_, value);
+}
+
 void EnumsWriter::Flush() {
   stream_.Flush();
 }
@@ -2194,6 +2198,10 @@ void EnumsReader::ReadSingleImpl(test_model::Fruits& value) {
 
 void EnumsReader::ReadVecImpl(std::vector<test_model::Fruits>& value) {
   yardl::binary::ReadVector<test_model::Fruits, yardl::binary::ReadEnum<test_model::Fruits>>(stream_, value);
+}
+
+void EnumsReader::ReadSizeImpl(test_model::SizeBasedEnum& value) {
+  yardl::binary::ReadEnum<test_model::SizeBasedEnum>(stream_, value);
 }
 
 void EnumsReader::CloseImpl() {

--- a/cpp/test/generated/binary/protocols.h
+++ b/cpp/test/generated/binary/protocols.h
@@ -752,6 +752,7 @@ class EnumsWriter : public test_model::EnumsWriterBase, yardl::binary::BinaryWri
   protected:
   void WriteSingleImpl(test_model::Fruits const& value) override;
   void WriteVecImpl(std::vector<test_model::Fruits> const& value) override;
+  void WriteSizeImpl(test_model::SizeBasedEnum const& value) override;
   void CloseImpl() override;
 };
 
@@ -768,6 +769,7 @@ class EnumsReader : public test_model::EnumsReaderBase, yardl::binary::BinaryRea
   protected:
   void ReadSingleImpl(test_model::Fruits& value) override;
   void ReadVecImpl(std::vector<test_model::Fruits>& value) override;
+  void ReadSizeImpl(test_model::SizeBasedEnum& value) override;
   void CloseImpl() override;
 };
 

--- a/cpp/test/generated/hdf5/protocols.cc
+++ b/cpp/test/generated/hdf5/protocols.cc
@@ -130,6 +130,17 @@ namespace {
   return t;
 };
 
+[[maybe_unused]] H5::EnumType GetSizeBasedEnumHdf5Ddl() {
+  H5::EnumType t(yardl::hdf5::SizeTypeDdl());
+  size_t i = 0ULL;
+  t.insert("a", &i);
+  i = 1ULL;
+  t.insert("b", &i);
+  i = 2ULL;
+  t.insert("c", &i);
+  return t;
+};
+
 [[maybe_unused]] H5::EnumType GetEnumWithKeywordSymbolsHdf5Ddl() {
   H5::EnumType t(H5::PredType::NATIVE_INT32);
   int32_t i = 2;
@@ -1776,6 +1787,10 @@ void EnumsWriter::WriteVecImpl(std::vector<test_model::Fruits> const& value) {
   yardl::hdf5::WriteScalarDataset<yardl::hdf5::InnerVlen<test_model::Fruits, test_model::Fruits>, std::vector<test_model::Fruits>>(group_, "vec", yardl::hdf5::InnerVlenDdl(test_model::hdf5::GetFruitsHdf5Ddl()), value);
 }
 
+void EnumsWriter::WriteSizeImpl(test_model::SizeBasedEnum const& value) {
+  yardl::hdf5::WriteScalarDataset<test_model::SizeBasedEnum, test_model::SizeBasedEnum>(group_, "size", test_model::hdf5::GetSizeBasedEnumHdf5Ddl(), value);
+}
+
 EnumsReader::EnumsReader(std::string path)
     : yardl::hdf5::Hdf5Reader::Hdf5Reader(path, "Enums", schema_) {
 }
@@ -1786,6 +1801,10 @@ void EnumsReader::ReadSingleImpl(test_model::Fruits& value) {
 
 void EnumsReader::ReadVecImpl(std::vector<test_model::Fruits>& value) {
   yardl::hdf5::ReadScalarDataset<yardl::hdf5::InnerVlen<test_model::Fruits, test_model::Fruits>, std::vector<test_model::Fruits>>(group_, "vec", yardl::hdf5::InnerVlenDdl(test_model::hdf5::GetFruitsHdf5Ddl()), value);
+}
+
+void EnumsReader::ReadSizeImpl(test_model::SizeBasedEnum& value) {
+  yardl::hdf5::ReadScalarDataset<test_model::SizeBasedEnum, test_model::SizeBasedEnum>(group_, "size", test_model::hdf5::GetSizeBasedEnumHdf5Ddl(), value);
 }
 
 StateTestWriter::StateTestWriter(std::string path)

--- a/cpp/test/generated/hdf5/protocols.h
+++ b/cpp/test/generated/hdf5/protocols.h
@@ -608,6 +608,8 @@ class EnumsWriter : public test_model::EnumsWriterBase, public yardl::hdf5::Hdf5
 
   void WriteVecImpl(std::vector<test_model::Fruits> const& value) override;
 
+  void WriteSizeImpl(test_model::SizeBasedEnum const& value) override;
+
   private:
 };
 
@@ -619,6 +621,8 @@ class EnumsReader : public test_model::EnumsReaderBase, public yardl::hdf5::Hdf5
   void ReadSingleImpl(test_model::Fruits& value) override;
 
   void ReadVecImpl(std::vector<test_model::Fruits>& value) override;
+
+  void ReadSizeImpl(test_model::SizeBasedEnum& value) override;
 
   private:
 };

--- a/cpp/test/generated/mocks.cc
+++ b/cpp/test/generated/mocks.cc
@@ -2170,12 +2170,31 @@ class MockEnumsWriter : public EnumsWriterBase {
     WriteVecImpl_expected_values_.push(value);
   }
 
+  void WriteSizeImpl (test_model::SizeBasedEnum const& value) override {
+    if (WriteSizeImpl_expected_values_.empty()) {
+      throw std::runtime_error("Unexpected call to WriteSizeImpl");
+    }
+    if (WriteSizeImpl_expected_values_.front() != value) {
+      throw std::runtime_error("Unexpected argument value for call to WriteSizeImpl");
+    }
+    WriteSizeImpl_expected_values_.pop();
+  }
+
+  std::queue<test_model::SizeBasedEnum> WriteSizeImpl_expected_values_;
+
+  void ExpectWriteSizeImpl (test_model::SizeBasedEnum const& value) {
+    WriteSizeImpl_expected_values_.push(value);
+  }
+
   void Verify() {
     if (!WriteSingleImpl_expected_values_.empty()) {
       throw std::runtime_error("Expected call to WriteSingleImpl was not received");
     }
     if (!WriteVecImpl_expected_values_.empty()) {
       throw std::runtime_error("Expected call to WriteVecImpl was not received");
+    }
+    if (!WriteSizeImpl_expected_values_.empty()) {
+      throw std::runtime_error("Expected call to WriteSizeImpl was not received");
     }
   }
 };
@@ -2200,6 +2219,11 @@ class TestEnumsWriterBase : public EnumsWriterBase {
   void WriteVecImpl(std::vector<test_model::Fruits> const& value) override {
     writer_->WriteVec(value);
     mock_writer_.ExpectWriteVecImpl(value);
+  }
+
+  void WriteSizeImpl(test_model::SizeBasedEnum const& value) override {
+    writer_->WriteSize(value);
+    mock_writer_.ExpectWriteSizeImpl(value);
   }
 
   void CloseImpl() override {

--- a/cpp/test/generated/model.json
+++ b/cpp/test/generated/model.json
@@ -813,6 +813,26 @@
           }
         },
         {
+          "enum": {
+            "name": "SizeBasedEnum",
+            "base": "size",
+            "values": [
+              {
+                "symbol": "a",
+                "value": 0
+              },
+              {
+                "symbol": "b",
+                "value": 1
+              },
+              {
+                "symbol": "c",
+                "value": 2
+              }
+            ]
+          }
+        },
+        {
           "alias": {
             "name": "Image",
             "typeParameters": [
@@ -2670,6 +2690,10 @@
                   ]
                 }
               }
+            },
+            {
+              "name": "size",
+              "type": "TestModel.SizeBasedEnum"
             }
           ]
         },

--- a/cpp/test/generated/protocols.cc
+++ b/cpp/test/generated/protocols.cc
@@ -3046,12 +3046,14 @@ void EnumsWriterBaseInvalidState(uint8_t attempted, [[maybe_unused]] bool end, u
   switch (current) {
   case 0: expected_method = "WriteSingle()"; break;
   case 1: expected_method = "WriteVec()"; break;
+  case 2: expected_method = "WriteSize()"; break;
   }
   std::string attempted_method;
   switch (attempted) {
   case 0: attempted_method = "WriteSingle()"; break;
   case 1: attempted_method = "WriteVec()"; break;
-  case 2: attempted_method = "Close()"; break;
+  case 2: attempted_method = "WriteSize()"; break;
+  case 3: attempted_method = "Close()"; break;
   }
   throw std::runtime_error("Expected call to " + expected_method + " but received call to " + attempted_method + " instead.");
 }
@@ -3061,7 +3063,8 @@ void EnumsReaderBaseInvalidState(uint8_t attempted, uint8_t current) {
     switch (i/2) {
     case 0: return "ReadSingle()";
     case 1: return "ReadVec()";
-    case 2: return "Close()";
+    case 2: return "ReadSize()";
+    case 3: return "Close()";
     default: return "<unknown>";
     }
   };
@@ -3070,7 +3073,7 @@ void EnumsReaderBaseInvalidState(uint8_t attempted, uint8_t current) {
 
 } // namespace 
 
-std::string EnumsWriterBase::schema_ = R"({"protocol":{"name":"Enums","sequence":[{"name":"single","type":"TestModel.Fruits"},{"name":"vec","type":{"vector":{"items":["TestModel.Fruits"]}}}]},"types":[{"name":"Fruits","values":[{"symbol":"apple","value":0},{"symbol":"banana","value":1},{"symbol":"pear","value":2}]}]})";
+std::string EnumsWriterBase::schema_ = R"({"protocol":{"name":"Enums","sequence":[{"name":"single","type":"TestModel.Fruits"},{"name":"vec","type":{"vector":{"items":["TestModel.Fruits"]}}},{"name":"size","type":"TestModel.SizeBasedEnum"}]},"types":[{"name":"Fruits","values":[{"symbol":"apple","value":0},{"symbol":"banana","value":1},{"symbol":"pear","value":2}]},{"name":"SizeBasedEnum","base":"size","values":[{"symbol":"a","value":0},{"symbol":"b","value":1},{"symbol":"c","value":2}]}]})";
 
 void EnumsWriterBase::WriteSingle(test_model::Fruits const& value) {
   if (unlikely(state_ != 0)) {
@@ -3090,9 +3093,18 @@ void EnumsWriterBase::WriteVec(std::vector<test_model::Fruits> const& value) {
   state_ = 2;
 }
 
-void EnumsWriterBase::Close() {
+void EnumsWriterBase::WriteSize(test_model::SizeBasedEnum const& value) {
   if (unlikely(state_ != 2)) {
     EnumsWriterBaseInvalidState(2, false, state_);
+  }
+
+  WriteSizeImpl(value);
+  state_ = 3;
+}
+
+void EnumsWriterBase::Close() {
+  if (unlikely(state_ != 3)) {
+    EnumsWriterBaseInvalidState(3, false, state_);
   }
 
   CloseImpl();
@@ -3118,9 +3130,18 @@ void EnumsReaderBase::ReadVec(std::vector<test_model::Fruits>& value) {
   state_ = 4;
 }
 
-void EnumsReaderBase::Close() {
+void EnumsReaderBase::ReadSize(test_model::SizeBasedEnum& value) {
   if (unlikely(state_ != 4)) {
     EnumsReaderBaseInvalidState(4, state_);
+  }
+
+  ReadSizeImpl(value);
+  state_ = 6;
+}
+
+void EnumsReaderBase::Close() {
+  if (unlikely(state_ != 6)) {
+    EnumsReaderBaseInvalidState(6, state_);
   }
 
   CloseImpl();
@@ -3135,6 +3156,11 @@ void EnumsReaderBase::CopyTo(EnumsWriterBase& writer) {
     std::vector<test_model::Fruits> value;
     ReadVec(value);
     writer.WriteVec(value);
+  }
+  {
+    test_model::SizeBasedEnum value;
+    ReadSize(value);
+    writer.WriteSize(value);
   }
 }
 

--- a/cpp/test/generated/protocols.h
+++ b/cpp/test/generated/protocols.h
@@ -1327,6 +1327,9 @@ class EnumsWriterBase {
   // Ordinal 1.
   void WriteVec(std::vector<test_model::Fruits> const& value);
 
+  // Ordinal 2.
+  void WriteSize(test_model::SizeBasedEnum const& value);
+
   // Optionaly close this writer before destructing. Validates that all steps were completed.
   void Close();
 
@@ -1338,6 +1341,7 @@ class EnumsWriterBase {
   protected:
   virtual void WriteSingleImpl(test_model::Fruits const& value) = 0;
   virtual void WriteVecImpl(std::vector<test_model::Fruits> const& value) = 0;
+  virtual void WriteSizeImpl(test_model::SizeBasedEnum const& value) = 0;
   virtual void CloseImpl() {}
 
   static std::string schema_;
@@ -1357,6 +1361,9 @@ class EnumsReaderBase {
   // Ordinal 1.
   void ReadVec(std::vector<test_model::Fruits>& value);
 
+  // Ordinal 2.
+  void ReadSize(test_model::SizeBasedEnum& value);
+
   // Optionaly close this writer before destructing. Validates that all steps were completely read.
   void Close();
 
@@ -1367,6 +1374,7 @@ class EnumsReaderBase {
   protected:
   virtual void ReadSingleImpl(test_model::Fruits& value) = 0;
   virtual void ReadVecImpl(std::vector<test_model::Fruits>& value) = 0;
+  virtual void ReadSizeImpl(test_model::SizeBasedEnum& value) = 0;
   virtual void CloseImpl() {}
   static std::string schema_;
 

--- a/cpp/test/generated/types.h
+++ b/cpp/test/generated/types.h
@@ -362,6 +362,12 @@ enum class Int64Enum : int64_t {
   kB = -4611686018427387904LL,
 };
 
+enum class SizeBasedEnum : size_t {
+  kA = 0ULL,
+  kB = 1ULL,
+  kC = 2ULL,
+};
+
 template <typename T>
 using Image = yardl::NDArray<T, 2>;
 

--- a/cpp/test/roundtrip_test.cc
+++ b/cpp/test/roundtrip_test.cc
@@ -389,6 +389,7 @@ TEST_P(RoundTripTests, Enums) {
   auto tw = CreateValidatingWriter<EnumsWriterBase>();
   tw->WriteSingle(Fruits::kApple);
   tw->WriteVec({Fruits::kApple, Fruits::kBanana});
+  tw->WriteSize(SizeBasedEnum::kC);
 
   tw->Close();
 }

--- a/models/test/unittests.yml
+++ b/models/test/unittests.yml
@@ -321,10 +321,15 @@ Int64Enum: !enum
   values:
     b: -0x4000000000000000
 
+SizeBasedEnum: !enum
+  base: size
+  values: [a,b,c]
+
 Enums: !protocol
   sequence:
     single: Fruits
     vec: !vector { items: Fruits }
+    size: SizeBasedEnum
 
 StateTest: !protocol
   sequence:

--- a/tooling/internal/cpp/include/detail/hdf5/ddl.h
+++ b/tooling/internal/cpp/include/detail/hdf5/ddl.h
@@ -26,7 +26,7 @@ namespace yardl::hdf5 {
 /**
  * @brief Returns the HDF5 type for size_t.
  */
-static inline H5::DataType SizeTypeDdl() {
+static inline H5::PredType const& SizeTypeDdl() {
   static_assert(sizeof(hsize_t) == sizeof(size_t));
   static_assert(std::is_signed_v<hsize_t> == std::is_signed_v<size_t>);
   return H5::PredType::NATIVE_HSIZE;


### PR DESCRIPTION
You can specify `size` as the base of an enum since it is an integer type, but the generated HDF5 code did not compile. 

Addresses #26. 