### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set path
         run: |
           chmod +x "${{github.workspace}}/yardl_darwin_amd64_v1/yardl"
-          echo "${{github.workspace}}/yardl_darwin_amd64_v1" >> $GITHUB_PATH 
+          echo "${{github.workspace}}/yardl_darwin_amd64_v1" >> $GITHUB_PATH
 
       - name: Run smoke test
         run: ./smoketest/run-smoketest-macos.sh
@@ -98,6 +98,7 @@ jobs:
   codeQL:
     name: CodeQL
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/yardl'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,6 @@ jobs:
     if: github.event_name == 'push' && github.ref_type == 'tag'
     needs:
       - validate
-      - codeQL
       - smoketestWindows
       - smoketestMac
       - noticeCheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - run: git fetch --force --tags
 
       - name: Configure environment
         uses: ./.github/actions/configure-environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
       - validate
       - codeQL
       - smoketestWindows
+      - smoketestMac
       - noticeCheck
     runs-on: ubuntu-latest
     steps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,4 +28,6 @@ changelog:
       - '^docs:'
       - '^test:'
 
+release:
+  draft: true
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
- We were not cloning the repo properly so goreleaser could not see all commits since the last release. This resulted in an incomplete changelog.
- Create a draft release so we have a chance to modify it before publishing
- Disable CodeQL on forks