### PR TITLE
Use Mambaforge for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,8 +30,13 @@ ARG CONDA_GID=900
 ARG CONDA_ENVIRONMENT_NAME=yardl
 ARG VSCODE_DEV_CONTAINERS_SCRIPT_LIBRARY_VERSION=v0.229.0
 
-RUN apt-get update && apt-get install -y \
-    libc6-dbg \
+RUN apt-get update \
+    && apt-get install -y \
+        libc6-dbg \
+        wget \
+        bzip2 \
+        ca-certificates \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Enable non-root Docker access in container
@@ -46,17 +51,16 @@ RUN script=$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-
 ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
 CMD [ "sleep", "infinity" ]
 
-ARG MAMBA_VERSION=0.22.1
+ARG MAMBAFORGE_VERSION=22.9.0-2
 
-# Based on https://github.com/ContinuumIO/docker-images/blob/master/miniconda3/debian/Dockerfile.
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh \
-    && mkdir -p /opt \
-    && sh miniconda.sh -b -p /opt/conda \
-    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
-    && find /opt/conda/ -follow -type f -name '*.a' -delete \
-    && find /opt/conda/ -follow -type f -name '*.js.map' -delete \
-    && /opt/conda/bin/conda install -n base -c conda-forge mamba=${MAMBA_VERSION} \
-    && /opt/conda/bin/conda clean -afy \
+# Based on https://github.com/conda-forge/miniforge-images/blob/master/ubuntu/Dockerfile
+RUN wget --no-hsts --quiet https://github.com/conda-forge/miniforge/releases/download/${MAMBAFORGE_VERSION}/Mambaforge-${MAMBAFORGE_VERSION}-Linux-$(uname -m).sh -O /tmp/miniforge.sh \
+    && /bin/bash /tmp/miniforge.sh -b -p /opt/conda \
+    && rm /tmp/miniforge.sh \
+    && /opt/conda/bin/conda clean --tarballs --index-cache --packages --yes \
+    && find /opt/conda -follow -type f -name '*.a' -delete \
+    && find /opt/conda -follow -type f -name '*.pyc' -delete \
+    && /opt/conda/bin/conda clean --force-pkgs-dirs --all --yes  \
     && groupadd -r conda --gid ${CONDA_GID} \
     && usermod -aG conda ${USERNAME} \
     && chown -R :conda /opt/conda \


### PR DESCRIPTION
The latest conda version with the version of mamba we were installing in the base environment could no longer solve for the specification in enviroment.yml. But we were installing mamba in a way that is [no longer recommended](https://mamba.readthedocs.io/en/latest/installation.html).

Instead, we install mamba via mambaforge and pin the version.  