### PR TITLE
Validate type parameters are all used

### DIFF
--- a/tooling/pkg/dsl/types_test.go
+++ b/tooling/pkg/dsl/types_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) {
+func TestTypeEquality(t *testing.T) {
 	testCases := []struct {
 		spec           string
 		expectedResult bool

--- a/tooling/pkg/dsl/validation.go
+++ b/tooling/pkg/dsl/validation.go
@@ -40,6 +40,7 @@ func Validate(namespaces []*Namespace) (*Environment, error) {
 		validateUnionCases,
 		validateEnums,
 		resolveComputedFields,
+		validateGenericParametersUsed,
 	}
 
 	for _, pass := range passes {

--- a/tooling/pkg/dsl/validation_type_resolution_test.go
+++ b/tooling/pkg/dsl/validation_type_resolution_test.go
@@ -83,3 +83,12 @@ Rec2: !record
 	_, err := parseAndValidate(t, src)
 	assert.ErrorContains(t, err, "the type 'Foo' is not recognized")
 }
+
+func TestTypeParameterUnused(t *testing.T) {
+	src := `
+MyUnion<T, U>: [T, int]
+`
+
+	_, err := parseAndValidate(t, src)
+	assert.ErrorContains(t, err, "generic type parameter 'U' is not used")
+}

--- a/tooling/pkg/dsl/validation_unions_test.go
+++ b/tooling/pkg/dsl/validation_unions_test.go
@@ -74,7 +74,9 @@ func TestUnionElementsAreDistinctWithGenerics(t *testing.T) {
 X: !record
   fields:
     f: [GenericRecord<float>, GenericRecord<double>]
-GenericRecord<T>: !record`
+GenericRecord<T>: !record
+  fields:
+    t: T`
 
 	_, err := parseAndValidate(t, src)
 	assert.Nil(t, err)

--- a/tooling/pkg/dsl/yaml.go
+++ b/tooling/pkg/dsl/yaml.go
@@ -83,6 +83,10 @@ func ParseYamlInDir(path string, namespaceName string) (*Namespace, error) {
 			Visit(&ns, func(self Visitor, node Node) {
 				switch node := node.(type) {
 				case *Namespace:
+				case *DefinitionMeta:
+					for _, p := range node.TypeParameters {
+						self.Visit(p)
+					}
 				default:
 					nodeMeta := node.GetNodeMeta()
 					nodeMeta.File = path


### PR DESCRIPTION
Raise an error if a type has a generic type parameter that is not used. For example:

``` yaml
MyUnion<T, U>: [T, int]
```

Addresses #32