### PR TITLE
Do not use conda to install Go in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,11 +39,11 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Enable non-root Docker access in container
-ARG ENABLE_NONROOT_DOCKER="true"
 # Use the OSS Moby CLI instead of the licensed Docker CLI
 ARG USE_MOBY="false"
-RUN script=$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/${VSCODE_DEV_CONTAINERS_SCRIPT_LIBRARY_VERSION}/script-library/docker-debian.sh") && bash -c "$script" -- "${ENABLE_NONROOT_DOCKER}" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}" "${USE_MOBY}"
+ARG DOCKER_VERSION="20.10"
+RUN script=$(curl -fsSL "https://raw.githubusercontent.com/devcontainers/features/8d3685e09f18dd8b0a6bce50abe3e868dac27a69/src/docker-outside-of-docker/install.sh") \
+    && MOBY=${USE_MOBY} VERSION=${DOCKER_VERSION} bash -c "$script"
 
 # Setting the ENTRYPOINT to docker-init.sh will configure non-root access to
 # the Docker socket if "overrideCommand": false is set in devcontainer.json.
@@ -74,22 +74,15 @@ RUN umask 0002 \
     && /opt/conda/bin/mamba clean -fy \
     && sudo chown -R :conda /opt/conda/envs
 
-# Install go tools
-SHELL ["/bin/bash", "-e", "-c"]
-RUN . /opt/conda/etc/profile.d/conda.sh \
-    && conda activate ${CONDA_ENVIRONMENT_NAME}; \
-    export GOBIN=/opt/conda/envs/${CONDA_ENVIRONMENT_NAME}/bin; \
-    GO_TOOLS="\
-        golang.org/x/tools/gopls@latest \
-        honnef.co/go/tools/cmd/staticcheck@latest \
-        golang.org/x/lint/golint@latest \
-        github.com/mgechev/revive@latest \
-        github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest \
-        github.com/ramya-rao-a/go-outline@latest \
-        github.com/go-delve/delve/cmd/dlv@latest \
-        github.com/mitranim/gow@latest \
-        github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \
-    echo "${GO_TOOLS}" | xargs -n 1 go install
+# Install Go
+ARG GO_VERSION=1.20.2
+ENV GOROOT="/usr/local/go"
+ENV GOPATH="/go"
+ENV "PATH"="/usr/local/go/bin:/go/bin:${PATH}"
+RUN umask 0002 \
+    && script=$(curl -fsSL "https://raw.githubusercontent.com/devcontainers/features/8d3685e09f18dd8b0a6bce50abe3e868dac27a69/src/go/install.sh") \
+    && VERSION=${GO_VERSION} TARGET_GOPATH=${GOPATH} TARGET_GOROOT=${GOROOT} bash -c "$script" \
+    && chown -R "${USERNAME}:conda" "${GOROOT}" "${GOPATH}"
 
 # Install watchexec
 ARG WATCHEXEC_VERSION=1.20.4

--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -7,14 +7,14 @@ runs:
     - name: Initial setup
       shell: bash
       run: |
-        gobin="${RUNNER_TEMP}/bin"
-        echo "GOBIN=${gobin}" >> $GITHUB_ENV
-        echo "${gobin}" >> $GITHUB_PATH
-
-        # filter conda environment file
+.de         # filter conda environment file
         cat environment.yml | grep -v "#.*\<\local\>" > ci-environment.yml
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: yardl
         environment-file: ci-environment.yml
+
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.20.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18.3"
+          go-version: "1.20.2"
 
       - name: Build yardl binaries for multiple platforms
         uses: goreleaser/goreleaser-action@v3

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - fmt=8.1.1
   - gcc_linux-64=11.2.0
   - gdb=11.2 # local
-  - go=1.18.3
   - gtest=1.11.0
   - gmock=1.11.0
   - gxx_linux-64=11.2.0


### PR DESCRIPTION
The Go version in conda is still at 1.18.5 whereas the current version is 1.20.2. VsCode Go tools require a more recent version than the conda version, so we will install it outside of conda.