### PR TITLE
Update snake_case regex

### DIFF
--- a/cpp/test/definitions_test.cc
+++ b/cpp/test/definitions_test.cc
@@ -35,15 +35,15 @@ TEST(DefinitionsTests, ArrayFieldsHaveExpectedType) {
                                yardl::DynamicNDArray<int32_t>>);
   static_assert(std::is_same_v<decltype(RecordWithArrays::default_array_with_empty_dimension),
                                yardl::DynamicNDArray<int32_t>>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank1_array),
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_1_array),
                                yardl::NDArray<int32_t, 1>>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank2_array),
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_2_array),
                                yardl::NDArray<int32_t, 2>>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank2_array_with_named_dimensions),
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_2_array_with_named_dimensions),
                                yardl::NDArray<int32_t, 2>>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank2_fixed_array),
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_2_fixed_array),
                                yardl::FixedNDArray<int32_t, 3, 4>>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank2_fixed_array_with_named_dimensions),
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_2_fixed_array_with_named_dimensions),
                                yardl::FixedNDArray<int32_t, 3, 4>>);
   static_assert(std::is_same_v<decltype(RecordWithArrays::dynamic_array),
                                yardl::DynamicNDArray<int32_t>>);
@@ -56,16 +56,16 @@ TEST(DefinitionsTests, ArrayFieldsWithSimpleSyntaxHaveExpectedType) {
                                decltype(RecordWithArraysSimpleSyntax::default_array)>);
   static_assert(std::is_same_v<decltype(RecordWithArrays::default_array_with_empty_dimension),
                                decltype(RecordWithArraysSimpleSyntax::default_array_with_empty_dimension)>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank1_array),
-                               decltype(RecordWithArraysSimpleSyntax::rank1_array)>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank2_array),
-                               decltype(RecordWithArraysSimpleSyntax::rank2_array)>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank2_array_with_named_dimensions),
-                               decltype(RecordWithArraysSimpleSyntax::rank2_array_with_named_dimensions)>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank2_fixed_array),
-                               decltype(RecordWithArraysSimpleSyntax::rank2_fixed_array)>);
-  static_assert(std::is_same_v<decltype(RecordWithArrays::rank2_fixed_array_with_named_dimensions),
-                               decltype(RecordWithArraysSimpleSyntax::rank2_fixed_array_with_named_dimensions)>);
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_1_array),
+                               decltype(RecordWithArraysSimpleSyntax::rank_1_array)>);
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_2_array),
+                               decltype(RecordWithArraysSimpleSyntax::rank_2_array)>);
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_2_array_with_named_dimensions),
+                               decltype(RecordWithArraysSimpleSyntax::rank_2_array_with_named_dimensions)>);
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_2_fixed_array),
+                               decltype(RecordWithArraysSimpleSyntax::rank_2_fixed_array)>);
+  static_assert(std::is_same_v<decltype(RecordWithArrays::rank_2_fixed_array_with_named_dimensions),
+                               decltype(RecordWithArraysSimpleSyntax::rank_2_fixed_array_with_named_dimensions)>);
   static_assert(std::is_same_v<decltype(RecordWithArrays::dynamic_array),
                                decltype(RecordWithArraysSimpleSyntax::dynamic_array)>);
   static_assert(std::is_same_v<decltype(RecordWithArrays::array_of_vectors),

--- a/cpp/test/generated/binary/protocols.cc
+++ b/cpp/test/generated/binary/protocols.cc
@@ -70,24 +70,24 @@ struct IsTriviallySerializable<test_model::RecordWithPrimitives> {
   static constexpr bool value = 
     std::is_standard_layout_v<__T__> &&
     IsTriviallySerializable<decltype(__T__::bool_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::int8_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::uint8_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::int16_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::uint16_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::int32_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::uint32_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::int64_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::uint64_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::int_8_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::uint_8_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::int_16_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::uint_16_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::int_32_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::uint_32_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::int_64_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::uint_64_field)>::value &&
     IsTriviallySerializable<decltype(__T__::size_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::float32_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::float64_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::complexfloat32_field)>::value &&
-    IsTriviallySerializable<decltype(__T__::complexfloat64_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::float_32_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::float_64_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::complexfloat_32_field)>::value &&
+    IsTriviallySerializable<decltype(__T__::complexfloat_64_field)>::value &&
     IsTriviallySerializable<decltype(__T__::date_field)>::value &&
     IsTriviallySerializable<decltype(__T__::time_field)>::value &&
     IsTriviallySerializable<decltype(__T__::datetime_field)>::value &&
-    (sizeof(__T__) == (sizeof(__T__::bool_field) + sizeof(__T__::int8_field) + sizeof(__T__::uint8_field) + sizeof(__T__::int16_field) + sizeof(__T__::uint16_field) + sizeof(__T__::int32_field) + sizeof(__T__::uint32_field) + sizeof(__T__::int64_field) + sizeof(__T__::uint64_field) + sizeof(__T__::size_field) + sizeof(__T__::float32_field) + sizeof(__T__::float64_field) + sizeof(__T__::complexfloat32_field) + sizeof(__T__::complexfloat64_field) + sizeof(__T__::date_field) + sizeof(__T__::time_field) + sizeof(__T__::datetime_field))) &&
-    offsetof(__T__, bool_field) < offsetof(__T__, int8_field) && offsetof(__T__, int8_field) < offsetof(__T__, uint8_field) && offsetof(__T__, uint8_field) < offsetof(__T__, int16_field) && offsetof(__T__, int16_field) < offsetof(__T__, uint16_field) && offsetof(__T__, uint16_field) < offsetof(__T__, int32_field) && offsetof(__T__, int32_field) < offsetof(__T__, uint32_field) && offsetof(__T__, uint32_field) < offsetof(__T__, int64_field) && offsetof(__T__, int64_field) < offsetof(__T__, uint64_field) && offsetof(__T__, uint64_field) < offsetof(__T__, size_field) && offsetof(__T__, size_field) < offsetof(__T__, float32_field) && offsetof(__T__, float32_field) < offsetof(__T__, float64_field) && offsetof(__T__, float64_field) < offsetof(__T__, complexfloat32_field) && offsetof(__T__, complexfloat32_field) < offsetof(__T__, complexfloat64_field) && offsetof(__T__, complexfloat64_field) < offsetof(__T__, date_field) && offsetof(__T__, date_field) < offsetof(__T__, time_field) && offsetof(__T__, time_field) < offsetof(__T__, datetime_field);
+    (sizeof(__T__) == (sizeof(__T__::bool_field) + sizeof(__T__::int_8_field) + sizeof(__T__::uint_8_field) + sizeof(__T__::int_16_field) + sizeof(__T__::uint_16_field) + sizeof(__T__::int_32_field) + sizeof(__T__::uint_32_field) + sizeof(__T__::int_64_field) + sizeof(__T__::uint_64_field) + sizeof(__T__::size_field) + sizeof(__T__::float_32_field) + sizeof(__T__::float_64_field) + sizeof(__T__::complexfloat_32_field) + sizeof(__T__::complexfloat_64_field) + sizeof(__T__::date_field) + sizeof(__T__::time_field) + sizeof(__T__::datetime_field))) &&
+    offsetof(__T__, bool_field) < offsetof(__T__, int_8_field) && offsetof(__T__, int_8_field) < offsetof(__T__, uint_8_field) && offsetof(__T__, uint_8_field) < offsetof(__T__, int_16_field) && offsetof(__T__, int_16_field) < offsetof(__T__, uint_16_field) && offsetof(__T__, uint_16_field) < offsetof(__T__, int_32_field) && offsetof(__T__, int_32_field) < offsetof(__T__, uint_32_field) && offsetof(__T__, uint_32_field) < offsetof(__T__, int_64_field) && offsetof(__T__, int_64_field) < offsetof(__T__, uint_64_field) && offsetof(__T__, uint_64_field) < offsetof(__T__, size_field) && offsetof(__T__, size_field) < offsetof(__T__, float_32_field) && offsetof(__T__, float_32_field) < offsetof(__T__, float_64_field) && offsetof(__T__, float_64_field) < offsetof(__T__, complexfloat_32_field) && offsetof(__T__, complexfloat_32_field) < offsetof(__T__, complexfloat_64_field) && offsetof(__T__, complexfloat_64_field) < offsetof(__T__, date_field) && offsetof(__T__, date_field) < offsetof(__T__, time_field) && offsetof(__T__, time_field) < offsetof(__T__, datetime_field);
 };
 
 template <>
@@ -138,15 +138,15 @@ struct IsTriviallySerializable<test_model::RecordWithArrays> {
     std::is_standard_layout_v<__T__> &&
     IsTriviallySerializable<decltype(__T__::default_array)>::value &&
     IsTriviallySerializable<decltype(__T__::default_array_with_empty_dimension)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank1_array)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank2_array)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank2_array_with_named_dimensions)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank2_fixed_array)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank2_fixed_array_with_named_dimensions)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_1_array)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_2_array)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_2_array_with_named_dimensions)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_2_fixed_array)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_2_fixed_array_with_named_dimensions)>::value &&
     IsTriviallySerializable<decltype(__T__::dynamic_array)>::value &&
     IsTriviallySerializable<decltype(__T__::array_of_vectors)>::value &&
-    (sizeof(__T__) == (sizeof(__T__::default_array) + sizeof(__T__::default_array_with_empty_dimension) + sizeof(__T__::rank1_array) + sizeof(__T__::rank2_array) + sizeof(__T__::rank2_array_with_named_dimensions) + sizeof(__T__::rank2_fixed_array) + sizeof(__T__::rank2_fixed_array_with_named_dimensions) + sizeof(__T__::dynamic_array) + sizeof(__T__::array_of_vectors))) &&
-    offsetof(__T__, default_array) < offsetof(__T__, default_array_with_empty_dimension) && offsetof(__T__, default_array_with_empty_dimension) < offsetof(__T__, rank1_array) && offsetof(__T__, rank1_array) < offsetof(__T__, rank2_array) && offsetof(__T__, rank2_array) < offsetof(__T__, rank2_array_with_named_dimensions) && offsetof(__T__, rank2_array_with_named_dimensions) < offsetof(__T__, rank2_fixed_array) && offsetof(__T__, rank2_fixed_array) < offsetof(__T__, rank2_fixed_array_with_named_dimensions) && offsetof(__T__, rank2_fixed_array_with_named_dimensions) < offsetof(__T__, dynamic_array) && offsetof(__T__, dynamic_array) < offsetof(__T__, array_of_vectors);
+    (sizeof(__T__) == (sizeof(__T__::default_array) + sizeof(__T__::default_array_with_empty_dimension) + sizeof(__T__::rank_1_array) + sizeof(__T__::rank_2_array) + sizeof(__T__::rank_2_array_with_named_dimensions) + sizeof(__T__::rank_2_fixed_array) + sizeof(__T__::rank_2_fixed_array_with_named_dimensions) + sizeof(__T__::dynamic_array) + sizeof(__T__::array_of_vectors))) &&
+    offsetof(__T__, default_array) < offsetof(__T__, default_array_with_empty_dimension) && offsetof(__T__, default_array_with_empty_dimension) < offsetof(__T__, rank_1_array) && offsetof(__T__, rank_1_array) < offsetof(__T__, rank_2_array) && offsetof(__T__, rank_2_array) < offsetof(__T__, rank_2_array_with_named_dimensions) && offsetof(__T__, rank_2_array_with_named_dimensions) < offsetof(__T__, rank_2_fixed_array) && offsetof(__T__, rank_2_fixed_array) < offsetof(__T__, rank_2_fixed_array_with_named_dimensions) && offsetof(__T__, rank_2_fixed_array_with_named_dimensions) < offsetof(__T__, dynamic_array) && offsetof(__T__, dynamic_array) < offsetof(__T__, array_of_vectors);
 };
 
 template <>
@@ -156,15 +156,15 @@ struct IsTriviallySerializable<test_model::RecordWithArraysSimpleSyntax> {
     std::is_standard_layout_v<__T__> &&
     IsTriviallySerializable<decltype(__T__::default_array)>::value &&
     IsTriviallySerializable<decltype(__T__::default_array_with_empty_dimension)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank1_array)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank2_array)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank2_array_with_named_dimensions)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank2_fixed_array)>::value &&
-    IsTriviallySerializable<decltype(__T__::rank2_fixed_array_with_named_dimensions)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_1_array)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_2_array)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_2_array_with_named_dimensions)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_2_fixed_array)>::value &&
+    IsTriviallySerializable<decltype(__T__::rank_2_fixed_array_with_named_dimensions)>::value &&
     IsTriviallySerializable<decltype(__T__::dynamic_array)>::value &&
     IsTriviallySerializable<decltype(__T__::array_of_vectors)>::value &&
-    (sizeof(__T__) == (sizeof(__T__::default_array) + sizeof(__T__::default_array_with_empty_dimension) + sizeof(__T__::rank1_array) + sizeof(__T__::rank2_array) + sizeof(__T__::rank2_array_with_named_dimensions) + sizeof(__T__::rank2_fixed_array) + sizeof(__T__::rank2_fixed_array_with_named_dimensions) + sizeof(__T__::dynamic_array) + sizeof(__T__::array_of_vectors))) &&
-    offsetof(__T__, default_array) < offsetof(__T__, default_array_with_empty_dimension) && offsetof(__T__, default_array_with_empty_dimension) < offsetof(__T__, rank1_array) && offsetof(__T__, rank1_array) < offsetof(__T__, rank2_array) && offsetof(__T__, rank2_array) < offsetof(__T__, rank2_array_with_named_dimensions) && offsetof(__T__, rank2_array_with_named_dimensions) < offsetof(__T__, rank2_fixed_array) && offsetof(__T__, rank2_fixed_array) < offsetof(__T__, rank2_fixed_array_with_named_dimensions) && offsetof(__T__, rank2_fixed_array_with_named_dimensions) < offsetof(__T__, dynamic_array) && offsetof(__T__, dynamic_array) < offsetof(__T__, array_of_vectors);
+    (sizeof(__T__) == (sizeof(__T__::default_array) + sizeof(__T__::default_array_with_empty_dimension) + sizeof(__T__::rank_1_array) + sizeof(__T__::rank_2_array) + sizeof(__T__::rank_2_array_with_named_dimensions) + sizeof(__T__::rank_2_fixed_array) + sizeof(__T__::rank_2_fixed_array_with_named_dimensions) + sizeof(__T__::dynamic_array) + sizeof(__T__::array_of_vectors))) &&
+    offsetof(__T__, default_array) < offsetof(__T__, default_array_with_empty_dimension) && offsetof(__T__, default_array_with_empty_dimension) < offsetof(__T__, rank_1_array) && offsetof(__T__, rank_1_array) < offsetof(__T__, rank_2_array) && offsetof(__T__, rank_2_array) < offsetof(__T__, rank_2_array_with_named_dimensions) && offsetof(__T__, rank_2_array_with_named_dimensions) < offsetof(__T__, rank_2_fixed_array) && offsetof(__T__, rank_2_fixed_array) < offsetof(__T__, rank_2_fixed_array_with_named_dimensions) && offsetof(__T__, rank_2_fixed_array_with_named_dimensions) < offsetof(__T__, dynamic_array) && offsetof(__T__, dynamic_array) < offsetof(__T__, array_of_vectors);
 };
 
 template <>
@@ -284,12 +284,12 @@ struct IsTriviallySerializable<test_model::GenericRecord<T1, T2>> {
   using __T__ = test_model::GenericRecord<T1, T2>;
   static constexpr bool value = 
     std::is_standard_layout_v<__T__> &&
-    IsTriviallySerializable<decltype(__T__::scalar1)>::value &&
-    IsTriviallySerializable<decltype(__T__::scalar2)>::value &&
-    IsTriviallySerializable<decltype(__T__::vector1)>::value &&
-    IsTriviallySerializable<decltype(__T__::image2)>::value &&
-    (sizeof(__T__) == (sizeof(__T__::scalar1) + sizeof(__T__::scalar2) + sizeof(__T__::vector1) + sizeof(__T__::image2))) &&
-    offsetof(__T__, scalar1) < offsetof(__T__, scalar2) && offsetof(__T__, scalar2) < offsetof(__T__, vector1) && offsetof(__T__, vector1) < offsetof(__T__, image2);
+    IsTriviallySerializable<decltype(__T__::scalar_1)>::value &&
+    IsTriviallySerializable<decltype(__T__::scalar_2)>::value &&
+    IsTriviallySerializable<decltype(__T__::vector_1)>::value &&
+    IsTriviallySerializable<decltype(__T__::image_2)>::value &&
+    (sizeof(__T__) == (sizeof(__T__::scalar_1) + sizeof(__T__::scalar_2) + sizeof(__T__::vector_1) + sizeof(__T__::image_2))) &&
+    offsetof(__T__, scalar_1) < offsetof(__T__, scalar_2) && offsetof(__T__, scalar_2) < offsetof(__T__, vector_1) && offsetof(__T__, vector_1) < offsetof(__T__, image_2);
 };
 
 template <typename T1, typename T2>
@@ -545,19 +545,19 @@ namespace {
   }
 
   yardl::binary::WriteInteger(stream, value.bool_field);
-  yardl::binary::WriteInteger(stream, value.int8_field);
-  yardl::binary::WriteInteger(stream, value.uint8_field);
-  yardl::binary::WriteInteger(stream, value.int16_field);
-  yardl::binary::WriteInteger(stream, value.uint16_field);
-  yardl::binary::WriteInteger(stream, value.int32_field);
-  yardl::binary::WriteInteger(stream, value.uint32_field);
-  yardl::binary::WriteInteger(stream, value.int64_field);
-  yardl::binary::WriteInteger(stream, value.uint64_field);
+  yardl::binary::WriteInteger(stream, value.int_8_field);
+  yardl::binary::WriteInteger(stream, value.uint_8_field);
+  yardl::binary::WriteInteger(stream, value.int_16_field);
+  yardl::binary::WriteInteger(stream, value.uint_16_field);
+  yardl::binary::WriteInteger(stream, value.int_32_field);
+  yardl::binary::WriteInteger(stream, value.uint_32_field);
+  yardl::binary::WriteInteger(stream, value.int_64_field);
+  yardl::binary::WriteInteger(stream, value.uint_64_field);
   yardl::binary::WriteInteger(stream, value.size_field);
-  yardl::binary::WriteFloatingPoint(stream, value.float32_field);
-  yardl::binary::WriteFloatingPoint(stream, value.float64_field);
-  yardl::binary::WriteFloatingPoint(stream, value.complexfloat32_field);
-  yardl::binary::WriteFloatingPoint(stream, value.complexfloat64_field);
+  yardl::binary::WriteFloatingPoint(stream, value.float_32_field);
+  yardl::binary::WriteFloatingPoint(stream, value.float_64_field);
+  yardl::binary::WriteFloatingPoint(stream, value.complexfloat_32_field);
+  yardl::binary::WriteFloatingPoint(stream, value.complexfloat_64_field);
   yardl::binary::WriteDate(stream, value.date_field);
   yardl::binary::WriteTime(stream, value.time_field);
   yardl::binary::WriteDateTime(stream, value.datetime_field);
@@ -570,19 +570,19 @@ namespace {
   }
 
   yardl::binary::ReadInteger(stream, value.bool_field);
-  yardl::binary::ReadInteger(stream, value.int8_field);
-  yardl::binary::ReadInteger(stream, value.uint8_field);
-  yardl::binary::ReadInteger(stream, value.int16_field);
-  yardl::binary::ReadInteger(stream, value.uint16_field);
-  yardl::binary::ReadInteger(stream, value.int32_field);
-  yardl::binary::ReadInteger(stream, value.uint32_field);
-  yardl::binary::ReadInteger(stream, value.int64_field);
-  yardl::binary::ReadInteger(stream, value.uint64_field);
+  yardl::binary::ReadInteger(stream, value.int_8_field);
+  yardl::binary::ReadInteger(stream, value.uint_8_field);
+  yardl::binary::ReadInteger(stream, value.int_16_field);
+  yardl::binary::ReadInteger(stream, value.uint_16_field);
+  yardl::binary::ReadInteger(stream, value.int_32_field);
+  yardl::binary::ReadInteger(stream, value.uint_32_field);
+  yardl::binary::ReadInteger(stream, value.int_64_field);
+  yardl::binary::ReadInteger(stream, value.uint_64_field);
   yardl::binary::ReadInteger(stream, value.size_field);
-  yardl::binary::ReadFloatingPoint(stream, value.float32_field);
-  yardl::binary::ReadFloatingPoint(stream, value.float64_field);
-  yardl::binary::ReadFloatingPoint(stream, value.complexfloat32_field);
-  yardl::binary::ReadFloatingPoint(stream, value.complexfloat64_field);
+  yardl::binary::ReadFloatingPoint(stream, value.float_32_field);
+  yardl::binary::ReadFloatingPoint(stream, value.float_64_field);
+  yardl::binary::ReadFloatingPoint(stream, value.complexfloat_32_field);
+  yardl::binary::ReadFloatingPoint(stream, value.complexfloat_64_field);
   yardl::binary::ReadDate(stream, value.date_field);
   yardl::binary::ReadTime(stream, value.time_field);
   yardl::binary::ReadDateTime(stream, value.datetime_field);
@@ -672,11 +672,11 @@ namespace {
 
   yardl::binary::WriteDynamicNDArray<int32_t, yardl::binary::WriteInteger>(stream, value.default_array);
   yardl::binary::WriteDynamicNDArray<int32_t, yardl::binary::WriteInteger>(stream, value.default_array_with_empty_dimension);
-  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 1>(stream, value.rank1_array);
-  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 2>(stream, value.rank2_array);
-  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 2>(stream, value.rank2_array_with_named_dimensions);
-  yardl::binary::WriteFixedNDArray<int32_t, yardl::binary::WriteInteger, 3, 4>(stream, value.rank2_fixed_array);
-  yardl::binary::WriteFixedNDArray<int32_t, yardl::binary::WriteInteger, 3, 4>(stream, value.rank2_fixed_array_with_named_dimensions);
+  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 1>(stream, value.rank_1_array);
+  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 2>(stream, value.rank_2_array);
+  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 2>(stream, value.rank_2_array_with_named_dimensions);
+  yardl::binary::WriteFixedNDArray<int32_t, yardl::binary::WriteInteger, 3, 4>(stream, value.rank_2_fixed_array);
+  yardl::binary::WriteFixedNDArray<int32_t, yardl::binary::WriteInteger, 3, 4>(stream, value.rank_2_fixed_array_with_named_dimensions);
   yardl::binary::WriteDynamicNDArray<int32_t, yardl::binary::WriteInteger>(stream, value.dynamic_array);
   yardl::binary::WriteFixedNDArray<std::array<int32_t, 4>, yardl::binary::WriteArray<int32_t, yardl::binary::WriteInteger, 4>, 5>(stream, value.array_of_vectors);
 }
@@ -689,11 +689,11 @@ namespace {
 
   yardl::binary::ReadDynamicNDArray<int32_t, yardl::binary::ReadInteger>(stream, value.default_array);
   yardl::binary::ReadDynamicNDArray<int32_t, yardl::binary::ReadInteger>(stream, value.default_array_with_empty_dimension);
-  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 1>(stream, value.rank1_array);
-  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 2>(stream, value.rank2_array);
-  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 2>(stream, value.rank2_array_with_named_dimensions);
-  yardl::binary::ReadFixedNDArray<int32_t, yardl::binary::ReadInteger, 3, 4>(stream, value.rank2_fixed_array);
-  yardl::binary::ReadFixedNDArray<int32_t, yardl::binary::ReadInteger, 3, 4>(stream, value.rank2_fixed_array_with_named_dimensions);
+  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 1>(stream, value.rank_1_array);
+  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 2>(stream, value.rank_2_array);
+  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 2>(stream, value.rank_2_array_with_named_dimensions);
+  yardl::binary::ReadFixedNDArray<int32_t, yardl::binary::ReadInteger, 3, 4>(stream, value.rank_2_fixed_array);
+  yardl::binary::ReadFixedNDArray<int32_t, yardl::binary::ReadInteger, 3, 4>(stream, value.rank_2_fixed_array_with_named_dimensions);
   yardl::binary::ReadDynamicNDArray<int32_t, yardl::binary::ReadInteger>(stream, value.dynamic_array);
   yardl::binary::ReadFixedNDArray<std::array<int32_t, 4>, yardl::binary::ReadArray<int32_t, yardl::binary::ReadInteger, 4>, 5>(stream, value.array_of_vectors);
 }
@@ -706,11 +706,11 @@ namespace {
 
   yardl::binary::WriteDynamicNDArray<int32_t, yardl::binary::WriteInteger>(stream, value.default_array);
   yardl::binary::WriteDynamicNDArray<int32_t, yardl::binary::WriteInteger>(stream, value.default_array_with_empty_dimension);
-  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 1>(stream, value.rank1_array);
-  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 2>(stream, value.rank2_array);
-  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 2>(stream, value.rank2_array_with_named_dimensions);
-  yardl::binary::WriteFixedNDArray<int32_t, yardl::binary::WriteInteger, 3, 4>(stream, value.rank2_fixed_array);
-  yardl::binary::WriteFixedNDArray<int32_t, yardl::binary::WriteInteger, 3, 4>(stream, value.rank2_fixed_array_with_named_dimensions);
+  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 1>(stream, value.rank_1_array);
+  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 2>(stream, value.rank_2_array);
+  yardl::binary::WriteNDArray<int32_t, yardl::binary::WriteInteger, 2>(stream, value.rank_2_array_with_named_dimensions);
+  yardl::binary::WriteFixedNDArray<int32_t, yardl::binary::WriteInteger, 3, 4>(stream, value.rank_2_fixed_array);
+  yardl::binary::WriteFixedNDArray<int32_t, yardl::binary::WriteInteger, 3, 4>(stream, value.rank_2_fixed_array_with_named_dimensions);
   yardl::binary::WriteDynamicNDArray<int32_t, yardl::binary::WriteInteger>(stream, value.dynamic_array);
   yardl::binary::WriteFixedNDArray<std::array<int32_t, 4>, yardl::binary::WriteArray<int32_t, yardl::binary::WriteInteger, 4>, 5>(stream, value.array_of_vectors);
 }
@@ -723,11 +723,11 @@ namespace {
 
   yardl::binary::ReadDynamicNDArray<int32_t, yardl::binary::ReadInteger>(stream, value.default_array);
   yardl::binary::ReadDynamicNDArray<int32_t, yardl::binary::ReadInteger>(stream, value.default_array_with_empty_dimension);
-  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 1>(stream, value.rank1_array);
-  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 2>(stream, value.rank2_array);
-  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 2>(stream, value.rank2_array_with_named_dimensions);
-  yardl::binary::ReadFixedNDArray<int32_t, yardl::binary::ReadInteger, 3, 4>(stream, value.rank2_fixed_array);
-  yardl::binary::ReadFixedNDArray<int32_t, yardl::binary::ReadInteger, 3, 4>(stream, value.rank2_fixed_array_with_named_dimensions);
+  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 1>(stream, value.rank_1_array);
+  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 2>(stream, value.rank_2_array);
+  yardl::binary::ReadNDArray<int32_t, yardl::binary::ReadInteger, 2>(stream, value.rank_2_array_with_named_dimensions);
+  yardl::binary::ReadFixedNDArray<int32_t, yardl::binary::ReadInteger, 3, 4>(stream, value.rank_2_fixed_array);
+  yardl::binary::ReadFixedNDArray<int32_t, yardl::binary::ReadInteger, 3, 4>(stream, value.rank_2_fixed_array_with_named_dimensions);
   yardl::binary::ReadDynamicNDArray<int32_t, yardl::binary::ReadInteger>(stream, value.dynamic_array);
   yardl::binary::ReadFixedNDArray<std::array<int32_t, 4>, yardl::binary::ReadArray<int32_t, yardl::binary::ReadInteger, 4>, 5>(stream, value.array_of_vectors);
 }
@@ -1023,10 +1023,10 @@ template<typename T1, yardl::binary::Writer<T1> WriteT1, typename T2, yardl::bin
     return;
   }
 
-  WriteT1(stream, value.scalar1);
-  WriteT2(stream, value.scalar2);
-  yardl::binary::WriteVector<T1, WriteT1>(stream, value.vector1);
-  test_model::binary::WriteImage<T2, WriteT2>(stream, value.image2);
+  WriteT1(stream, value.scalar_1);
+  WriteT2(stream, value.scalar_2);
+  yardl::binary::WriteVector<T1, WriteT1>(stream, value.vector_1);
+  test_model::binary::WriteImage<T2, WriteT2>(stream, value.image_2);
 }
 
 template<typename T1, yardl::binary::Reader<T1> ReadT1, typename T2, yardl::binary::Reader<T2> ReadT2>
@@ -1036,10 +1036,10 @@ template<typename T1, yardl::binary::Reader<T1> ReadT1, typename T2, yardl::bina
     return;
   }
 
-  ReadT1(stream, value.scalar1);
-  ReadT2(stream, value.scalar2);
-  yardl::binary::ReadVector<T1, ReadT1>(stream, value.vector1);
-  test_model::binary::ReadImage<T2, ReadT2>(stream, value.image2);
+  ReadT1(stream, value.scalar_1);
+  ReadT2(stream, value.scalar_2);
+  yardl::binary::ReadVector<T1, ReadT1>(stream, value.vector_1);
+  test_model::binary::ReadImage<T2, ReadT2>(stream, value.image_2);
 }
 
 template<typename T1, yardl::binary::Writer<T1> WriteT1, typename T2, yardl::binary::Writer<T2> WriteT2>

--- a/cpp/test/generated/hdf5/protocols.cc
+++ b/cpp/test/generated/hdf5/protocols.cc
@@ -223,11 +223,11 @@ struct _Inner_RecordWithArrays {
   _Inner_RecordWithArrays(test_model::RecordWithArrays const& o) 
       : default_array(o.default_array),
       default_array_with_empty_dimension(o.default_array_with_empty_dimension),
-      rank1_array(o.rank1_array),
-      rank2_array(o.rank2_array),
-      rank2_array_with_named_dimensions(o.rank2_array_with_named_dimensions),
-      rank2_fixed_array(o.rank2_fixed_array),
-      rank2_fixed_array_with_named_dimensions(o.rank2_fixed_array_with_named_dimensions),
+      rank_1_array(o.rank_1_array),
+      rank_2_array(o.rank_2_array),
+      rank_2_array_with_named_dimensions(o.rank_2_array_with_named_dimensions),
+      rank_2_fixed_array(o.rank_2_fixed_array),
+      rank_2_fixed_array_with_named_dimensions(o.rank_2_fixed_array_with_named_dimensions),
       dynamic_array(o.dynamic_array),
       array_of_vectors(o.array_of_vectors) {
   }
@@ -235,22 +235,22 @@ struct _Inner_RecordWithArrays {
   void ToOuter (test_model::RecordWithArrays& o) const {
     yardl::hdf5::ToOuter(default_array, o.default_array);
     yardl::hdf5::ToOuter(default_array_with_empty_dimension, o.default_array_with_empty_dimension);
-    yardl::hdf5::ToOuter(rank1_array, o.rank1_array);
-    yardl::hdf5::ToOuter(rank2_array, o.rank2_array);
-    yardl::hdf5::ToOuter(rank2_array_with_named_dimensions, o.rank2_array_with_named_dimensions);
-    yardl::hdf5::ToOuter(rank2_fixed_array, o.rank2_fixed_array);
-    yardl::hdf5::ToOuter(rank2_fixed_array_with_named_dimensions, o.rank2_fixed_array_with_named_dimensions);
+    yardl::hdf5::ToOuter(rank_1_array, o.rank_1_array);
+    yardl::hdf5::ToOuter(rank_2_array, o.rank_2_array);
+    yardl::hdf5::ToOuter(rank_2_array_with_named_dimensions, o.rank_2_array_with_named_dimensions);
+    yardl::hdf5::ToOuter(rank_2_fixed_array, o.rank_2_fixed_array);
+    yardl::hdf5::ToOuter(rank_2_fixed_array_with_named_dimensions, o.rank_2_fixed_array_with_named_dimensions);
     yardl::hdf5::ToOuter(dynamic_array, o.dynamic_array);
     yardl::hdf5::ToOuter(array_of_vectors, o.array_of_vectors);
   }
 
   yardl::hdf5::InnerDynamicNdArray<int32_t, int32_t> default_array;
   yardl::hdf5::InnerDynamicNdArray<int32_t, int32_t> default_array_with_empty_dimension;
-  yardl::hdf5::InnerVlen<int32_t, int32_t> rank1_array;
-  yardl::hdf5::InnerNdArray<int32_t, int32_t, 2> rank2_array;
-  yardl::hdf5::InnerNdArray<int32_t, int32_t, 2> rank2_array_with_named_dimensions;
-  yardl::FixedNDArray<int32_t, 3, 4> rank2_fixed_array;
-  yardl::FixedNDArray<int32_t, 3, 4> rank2_fixed_array_with_named_dimensions;
+  yardl::hdf5::InnerVlen<int32_t, int32_t> rank_1_array;
+  yardl::hdf5::InnerNdArray<int32_t, int32_t, 2> rank_2_array;
+  yardl::hdf5::InnerNdArray<int32_t, int32_t, 2> rank_2_array_with_named_dimensions;
+  yardl::FixedNDArray<int32_t, 3, 4> rank_2_fixed_array;
+  yardl::FixedNDArray<int32_t, 3, 4> rank_2_fixed_array_with_named_dimensions;
   yardl::hdf5::InnerDynamicNdArray<int32_t, int32_t> dynamic_array;
   yardl::FixedNDArray<std::array<int32_t, 4>, 5> array_of_vectors;
 };
@@ -260,11 +260,11 @@ struct _Inner_RecordWithArraysSimpleSyntax {
   _Inner_RecordWithArraysSimpleSyntax(test_model::RecordWithArraysSimpleSyntax const& o) 
       : default_array(o.default_array),
       default_array_with_empty_dimension(o.default_array_with_empty_dimension),
-      rank1_array(o.rank1_array),
-      rank2_array(o.rank2_array),
-      rank2_array_with_named_dimensions(o.rank2_array_with_named_dimensions),
-      rank2_fixed_array(o.rank2_fixed_array),
-      rank2_fixed_array_with_named_dimensions(o.rank2_fixed_array_with_named_dimensions),
+      rank_1_array(o.rank_1_array),
+      rank_2_array(o.rank_2_array),
+      rank_2_array_with_named_dimensions(o.rank_2_array_with_named_dimensions),
+      rank_2_fixed_array(o.rank_2_fixed_array),
+      rank_2_fixed_array_with_named_dimensions(o.rank_2_fixed_array_with_named_dimensions),
       dynamic_array(o.dynamic_array),
       array_of_vectors(o.array_of_vectors) {
   }
@@ -272,22 +272,22 @@ struct _Inner_RecordWithArraysSimpleSyntax {
   void ToOuter (test_model::RecordWithArraysSimpleSyntax& o) const {
     yardl::hdf5::ToOuter(default_array, o.default_array);
     yardl::hdf5::ToOuter(default_array_with_empty_dimension, o.default_array_with_empty_dimension);
-    yardl::hdf5::ToOuter(rank1_array, o.rank1_array);
-    yardl::hdf5::ToOuter(rank2_array, o.rank2_array);
-    yardl::hdf5::ToOuter(rank2_array_with_named_dimensions, o.rank2_array_with_named_dimensions);
-    yardl::hdf5::ToOuter(rank2_fixed_array, o.rank2_fixed_array);
-    yardl::hdf5::ToOuter(rank2_fixed_array_with_named_dimensions, o.rank2_fixed_array_with_named_dimensions);
+    yardl::hdf5::ToOuter(rank_1_array, o.rank_1_array);
+    yardl::hdf5::ToOuter(rank_2_array, o.rank_2_array);
+    yardl::hdf5::ToOuter(rank_2_array_with_named_dimensions, o.rank_2_array_with_named_dimensions);
+    yardl::hdf5::ToOuter(rank_2_fixed_array, o.rank_2_fixed_array);
+    yardl::hdf5::ToOuter(rank_2_fixed_array_with_named_dimensions, o.rank_2_fixed_array_with_named_dimensions);
     yardl::hdf5::ToOuter(dynamic_array, o.dynamic_array);
     yardl::hdf5::ToOuter(array_of_vectors, o.array_of_vectors);
   }
 
   yardl::hdf5::InnerDynamicNdArray<int32_t, int32_t> default_array;
   yardl::hdf5::InnerDynamicNdArray<int32_t, int32_t> default_array_with_empty_dimension;
-  yardl::hdf5::InnerVlen<int32_t, int32_t> rank1_array;
-  yardl::hdf5::InnerNdArray<int32_t, int32_t, 2> rank2_array;
-  yardl::hdf5::InnerNdArray<int32_t, int32_t, 2> rank2_array_with_named_dimensions;
-  yardl::FixedNDArray<int32_t, 3, 4> rank2_fixed_array;
-  yardl::FixedNDArray<int32_t, 3, 4> rank2_fixed_array_with_named_dimensions;
+  yardl::hdf5::InnerVlen<int32_t, int32_t> rank_1_array;
+  yardl::hdf5::InnerNdArray<int32_t, int32_t, 2> rank_2_array;
+  yardl::hdf5::InnerNdArray<int32_t, int32_t, 2> rank_2_array_with_named_dimensions;
+  yardl::FixedNDArray<int32_t, 3, 4> rank_2_fixed_array;
+  yardl::FixedNDArray<int32_t, 3, 4> rank_2_fixed_array_with_named_dimensions;
   yardl::hdf5::InnerDynamicNdArray<int32_t, int32_t> dynamic_array;
   yardl::FixedNDArray<std::array<int32_t, 4>, 5> array_of_vectors;
 };
@@ -468,23 +468,23 @@ template <typename _T1_Inner, typename T1, typename _T2_Inner, typename T2>
 struct _Inner_GenericRecord {
   _Inner_GenericRecord() {} 
   _Inner_GenericRecord(test_model::GenericRecord<T1, T2> const& o) 
-      : scalar1(o.scalar1),
-      scalar2(o.scalar2),
-      vector1(o.vector1),
-      image2(o.image2) {
+      : scalar_1(o.scalar_1),
+      scalar_2(o.scalar_2),
+      vector_1(o.vector_1),
+      image_2(o.image_2) {
   }
 
   void ToOuter (test_model::GenericRecord<T1, T2>& o) const {
-    yardl::hdf5::ToOuter(scalar1, o.scalar1);
-    yardl::hdf5::ToOuter(scalar2, o.scalar2);
-    yardl::hdf5::ToOuter(vector1, o.vector1);
-    yardl::hdf5::ToOuter(image2, o.image2);
+    yardl::hdf5::ToOuter(scalar_1, o.scalar_1);
+    yardl::hdf5::ToOuter(scalar_2, o.scalar_2);
+    yardl::hdf5::ToOuter(vector_1, o.vector_1);
+    yardl::hdf5::ToOuter(image_2, o.image_2);
   }
 
-  _T1_Inner scalar1;
-  _T2_Inner scalar2;
-  yardl::hdf5::InnerVlen<_T1_Inner, T1> vector1;
-  yardl::hdf5::InnerNdArray<_T2_Inner, T2, 2> image2;
+  _T1_Inner scalar_1;
+  _T2_Inner scalar_2;
+  yardl::hdf5::InnerVlen<_T1_Inner, T1> vector_1;
+  yardl::hdf5::InnerNdArray<_T2_Inner, T2, 2> image_2;
 };
 
 template <typename _T1_Inner, typename T1, typename _T2_Inner, typename T2>
@@ -634,19 +634,19 @@ struct _Inner_RecordWithKeywordFields {
   using RecordType = test_model::RecordWithPrimitives;
   H5::CompType t(sizeof(RecordType));
   t.insertMember("boolField", HOFFSET(RecordType, bool_field), H5::PredType::NATIVE_HBOOL);
-  t.insertMember("int8Field", HOFFSET(RecordType, int8_field), H5::PredType::NATIVE_INT8);
-  t.insertMember("uint8Field", HOFFSET(RecordType, uint8_field), H5::PredType::NATIVE_UINT8);
-  t.insertMember("int16Field", HOFFSET(RecordType, int16_field), H5::PredType::NATIVE_INT16);
-  t.insertMember("uint16Field", HOFFSET(RecordType, uint16_field), H5::PredType::NATIVE_UINT16);
-  t.insertMember("int32Field", HOFFSET(RecordType, int32_field), H5::PredType::NATIVE_INT32);
-  t.insertMember("uint32Field", HOFFSET(RecordType, uint32_field), H5::PredType::NATIVE_UINT32);
-  t.insertMember("int64Field", HOFFSET(RecordType, int64_field), H5::PredType::NATIVE_INT64);
-  t.insertMember("uint64Field", HOFFSET(RecordType, uint64_field), H5::PredType::NATIVE_UINT64);
+  t.insertMember("int8Field", HOFFSET(RecordType, int_8_field), H5::PredType::NATIVE_INT8);
+  t.insertMember("uint8Field", HOFFSET(RecordType, uint_8_field), H5::PredType::NATIVE_UINT8);
+  t.insertMember("int16Field", HOFFSET(RecordType, int_16_field), H5::PredType::NATIVE_INT16);
+  t.insertMember("uint16Field", HOFFSET(RecordType, uint_16_field), H5::PredType::NATIVE_UINT16);
+  t.insertMember("int32Field", HOFFSET(RecordType, int_32_field), H5::PredType::NATIVE_INT32);
+  t.insertMember("uint32Field", HOFFSET(RecordType, uint_32_field), H5::PredType::NATIVE_UINT32);
+  t.insertMember("int64Field", HOFFSET(RecordType, int_64_field), H5::PredType::NATIVE_INT64);
+  t.insertMember("uint64Field", HOFFSET(RecordType, uint_64_field), H5::PredType::NATIVE_UINT64);
   t.insertMember("sizeField", HOFFSET(RecordType, size_field), yardl::hdf5::SizeTypeDdl());
-  t.insertMember("float32Field", HOFFSET(RecordType, float32_field), H5::PredType::NATIVE_FLOAT);
-  t.insertMember("float64Field", HOFFSET(RecordType, float64_field), H5::PredType::NATIVE_DOUBLE);
-  t.insertMember("complexfloat32Field", HOFFSET(RecordType, complexfloat32_field), yardl::hdf5::ComplexTypeDdl<float>());
-  t.insertMember("complexfloat64Field", HOFFSET(RecordType, complexfloat64_field), yardl::hdf5::ComplexTypeDdl<double>());
+  t.insertMember("float32Field", HOFFSET(RecordType, float_32_field), H5::PredType::NATIVE_FLOAT);
+  t.insertMember("float64Field", HOFFSET(RecordType, float_64_field), H5::PredType::NATIVE_DOUBLE);
+  t.insertMember("complexfloat32Field", HOFFSET(RecordType, complexfloat_32_field), yardl::hdf5::ComplexTypeDdl<float>());
+  t.insertMember("complexfloat64Field", HOFFSET(RecordType, complexfloat_64_field), yardl::hdf5::ComplexTypeDdl<double>());
   t.insertMember("dateField", HOFFSET(RecordType, date_field), yardl::hdf5::DateTypeDdl());
   t.insertMember("timeField", HOFFSET(RecordType, time_field), yardl::hdf5::TimeTypeDdl());
   t.insertMember("datetimeField", HOFFSET(RecordType, datetime_field), yardl::hdf5::DateTimeTypeDdl());
@@ -690,11 +690,11 @@ struct _Inner_RecordWithKeywordFields {
   H5::CompType t(sizeof(RecordType));
   t.insertMember("defaultArray", HOFFSET(RecordType, default_array), yardl::hdf5::DynamicNDArrayDdl<int32_t, int32_t>(H5::PredType::NATIVE_INT32));
   t.insertMember("defaultArrayWithEmptyDimension", HOFFSET(RecordType, default_array_with_empty_dimension), yardl::hdf5::DynamicNDArrayDdl<int32_t, int32_t>(H5::PredType::NATIVE_INT32));
-  t.insertMember("rank1Array", HOFFSET(RecordType, rank1_array), yardl::hdf5::InnerVlenDdl(H5::PredType::NATIVE_INT32));
-  t.insertMember("rank2Array", HOFFSET(RecordType, rank2_array), yardl::hdf5::NDArrayDdl<int32_t, int32_t, 2>(H5::PredType::NATIVE_INT32));
-  t.insertMember("rank2ArrayWithNamedDimensions", HOFFSET(RecordType, rank2_array_with_named_dimensions), yardl::hdf5::NDArrayDdl<int32_t, int32_t, 2>(H5::PredType::NATIVE_INT32));
-  t.insertMember("rank2FixedArray", HOFFSET(RecordType, rank2_fixed_array), yardl::hdf5::FixedNDArrayDdl(H5::PredType::NATIVE_INT32, {3, 4}));
-  t.insertMember("rank2FixedArrayWithNamedDimensions", HOFFSET(RecordType, rank2_fixed_array_with_named_dimensions), yardl::hdf5::FixedNDArrayDdl(H5::PredType::NATIVE_INT32, {3, 4}));
+  t.insertMember("rank1Array", HOFFSET(RecordType, rank_1_array), yardl::hdf5::InnerVlenDdl(H5::PredType::NATIVE_INT32));
+  t.insertMember("rank2Array", HOFFSET(RecordType, rank_2_array), yardl::hdf5::NDArrayDdl<int32_t, int32_t, 2>(H5::PredType::NATIVE_INT32));
+  t.insertMember("rank2ArrayWithNamedDimensions", HOFFSET(RecordType, rank_2_array_with_named_dimensions), yardl::hdf5::NDArrayDdl<int32_t, int32_t, 2>(H5::PredType::NATIVE_INT32));
+  t.insertMember("rank2FixedArray", HOFFSET(RecordType, rank_2_fixed_array), yardl::hdf5::FixedNDArrayDdl(H5::PredType::NATIVE_INT32, {3, 4}));
+  t.insertMember("rank2FixedArrayWithNamedDimensions", HOFFSET(RecordType, rank_2_fixed_array_with_named_dimensions), yardl::hdf5::FixedNDArrayDdl(H5::PredType::NATIVE_INT32, {3, 4}));
   t.insertMember("dynamicArray", HOFFSET(RecordType, dynamic_array), yardl::hdf5::DynamicNDArrayDdl<int32_t, int32_t>(H5::PredType::NATIVE_INT32));
   t.insertMember("arrayOfVectors", HOFFSET(RecordType, array_of_vectors), yardl::hdf5::FixedNDArrayDdl(yardl::hdf5::FixedVectorDdl(H5::PredType::NATIVE_INT32, 4), {5}));
   return t;
@@ -705,11 +705,11 @@ struct _Inner_RecordWithKeywordFields {
   H5::CompType t(sizeof(RecordType));
   t.insertMember("defaultArray", HOFFSET(RecordType, default_array), yardl::hdf5::DynamicNDArrayDdl<int32_t, int32_t>(H5::PredType::NATIVE_INT32));
   t.insertMember("defaultArrayWithEmptyDimension", HOFFSET(RecordType, default_array_with_empty_dimension), yardl::hdf5::DynamicNDArrayDdl<int32_t, int32_t>(H5::PredType::NATIVE_INT32));
-  t.insertMember("rank1Array", HOFFSET(RecordType, rank1_array), yardl::hdf5::InnerVlenDdl(H5::PredType::NATIVE_INT32));
-  t.insertMember("rank2Array", HOFFSET(RecordType, rank2_array), yardl::hdf5::NDArrayDdl<int32_t, int32_t, 2>(H5::PredType::NATIVE_INT32));
-  t.insertMember("rank2ArrayWithNamedDimensions", HOFFSET(RecordType, rank2_array_with_named_dimensions), yardl::hdf5::NDArrayDdl<int32_t, int32_t, 2>(H5::PredType::NATIVE_INT32));
-  t.insertMember("rank2FixedArray", HOFFSET(RecordType, rank2_fixed_array), yardl::hdf5::FixedNDArrayDdl(H5::PredType::NATIVE_INT32, {3, 4}));
-  t.insertMember("rank2FixedArrayWithNamedDimensions", HOFFSET(RecordType, rank2_fixed_array_with_named_dimensions), yardl::hdf5::FixedNDArrayDdl(H5::PredType::NATIVE_INT32, {3, 4}));
+  t.insertMember("rank1Array", HOFFSET(RecordType, rank_1_array), yardl::hdf5::InnerVlenDdl(H5::PredType::NATIVE_INT32));
+  t.insertMember("rank2Array", HOFFSET(RecordType, rank_2_array), yardl::hdf5::NDArrayDdl<int32_t, int32_t, 2>(H5::PredType::NATIVE_INT32));
+  t.insertMember("rank2ArrayWithNamedDimensions", HOFFSET(RecordType, rank_2_array_with_named_dimensions), yardl::hdf5::NDArrayDdl<int32_t, int32_t, 2>(H5::PredType::NATIVE_INT32));
+  t.insertMember("rank2FixedArray", HOFFSET(RecordType, rank_2_fixed_array), yardl::hdf5::FixedNDArrayDdl(H5::PredType::NATIVE_INT32, {3, 4}));
+  t.insertMember("rank2FixedArrayWithNamedDimensions", HOFFSET(RecordType, rank_2_fixed_array_with_named_dimensions), yardl::hdf5::FixedNDArrayDdl(H5::PredType::NATIVE_INT32, {3, 4}));
   t.insertMember("dynamicArray", HOFFSET(RecordType, dynamic_array), yardl::hdf5::DynamicNDArrayDdl<int32_t, int32_t>(H5::PredType::NATIVE_INT32));
   t.insertMember("arrayOfVectors", HOFFSET(RecordType, array_of_vectors), yardl::hdf5::FixedNDArrayDdl(yardl::hdf5::FixedVectorDdl(H5::PredType::NATIVE_INT32, 4), {5}));
   return t;
@@ -803,10 +803,10 @@ template <typename _T1_Inner, typename T1, typename _T2_Inner, typename T2>
 [[maybe_unused]] H5::CompType GetGenericRecordHdf5Ddl(H5::DataType const& T1_type, H5::DataType const& T2_type) {
   using RecordType = test_model::hdf5::_Inner_GenericRecord<_T1_Inner, T1, _T2_Inner, T2>;
   H5::CompType t(sizeof(RecordType));
-  t.insertMember("scalar1", HOFFSET(RecordType, scalar1), T1_type);
-  t.insertMember("scalar2", HOFFSET(RecordType, scalar2), T2_type);
-  t.insertMember("vector1", HOFFSET(RecordType, vector1), yardl::hdf5::InnerVlenDdl(T1_type));
-  t.insertMember("image2", HOFFSET(RecordType, image2), yardl::hdf5::NDArrayDdl<_T2_Inner, T2, 2>(T2_type));
+  t.insertMember("scalar1", HOFFSET(RecordType, scalar_1), T1_type);
+  t.insertMember("scalar2", HOFFSET(RecordType, scalar_2), T2_type);
+  t.insertMember("vector1", HOFFSET(RecordType, vector_1), yardl::hdf5::InnerVlenDdl(T1_type));
+  t.insertMember("image2", HOFFSET(RecordType, image_2), yardl::hdf5::NDArrayDdl<_T2_Inner, T2, 2>(T2_type));
   return t;
 };
 

--- a/cpp/test/generated/ndjson/protocols.cc
+++ b/cpp/test/generated/ndjson/protocols.cc
@@ -527,44 +527,44 @@ void to_json(ordered_json& j, test_model::RecordWithPrimitives const& value) {
   if (yardl::ndjson::ShouldSerializeFieldValue(value.bool_field)) {
     j.push_back({"boolField", value.bool_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.int8_field)) {
-    j.push_back({"int8Field", value.int8_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.int_8_field)) {
+    j.push_back({"int8Field", value.int_8_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.uint8_field)) {
-    j.push_back({"uint8Field", value.uint8_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.uint_8_field)) {
+    j.push_back({"uint8Field", value.uint_8_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.int16_field)) {
-    j.push_back({"int16Field", value.int16_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.int_16_field)) {
+    j.push_back({"int16Field", value.int_16_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.uint16_field)) {
-    j.push_back({"uint16Field", value.uint16_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.uint_16_field)) {
+    j.push_back({"uint16Field", value.uint_16_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.int32_field)) {
-    j.push_back({"int32Field", value.int32_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.int_32_field)) {
+    j.push_back({"int32Field", value.int_32_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.uint32_field)) {
-    j.push_back({"uint32Field", value.uint32_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.uint_32_field)) {
+    j.push_back({"uint32Field", value.uint_32_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.int64_field)) {
-    j.push_back({"int64Field", value.int64_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.int_64_field)) {
+    j.push_back({"int64Field", value.int_64_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.uint64_field)) {
-    j.push_back({"uint64Field", value.uint64_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.uint_64_field)) {
+    j.push_back({"uint64Field", value.uint_64_field});
   }
   if (yardl::ndjson::ShouldSerializeFieldValue(value.size_field)) {
     j.push_back({"sizeField", value.size_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.float32_field)) {
-    j.push_back({"float32Field", value.float32_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.float_32_field)) {
+    j.push_back({"float32Field", value.float_32_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.float64_field)) {
-    j.push_back({"float64Field", value.float64_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.float_64_field)) {
+    j.push_back({"float64Field", value.float_64_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.complexfloat32_field)) {
-    j.push_back({"complexfloat32Field", value.complexfloat32_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.complexfloat_32_field)) {
+    j.push_back({"complexfloat32Field", value.complexfloat_32_field});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.complexfloat64_field)) {
-    j.push_back({"complexfloat64Field", value.complexfloat64_field});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.complexfloat_64_field)) {
+    j.push_back({"complexfloat64Field", value.complexfloat_64_field});
   }
   if (yardl::ndjson::ShouldSerializeFieldValue(value.date_field)) {
     j.push_back({"dateField", value.date_field});
@@ -582,43 +582,43 @@ void from_json(ordered_json const& j, test_model::RecordWithPrimitives& value) {
     it->get_to(value.bool_field);
   }
   if (auto it = j.find("int8Field"); it != j.end()) {
-    it->get_to(value.int8_field);
+    it->get_to(value.int_8_field);
   }
   if (auto it = j.find("uint8Field"); it != j.end()) {
-    it->get_to(value.uint8_field);
+    it->get_to(value.uint_8_field);
   }
   if (auto it = j.find("int16Field"); it != j.end()) {
-    it->get_to(value.int16_field);
+    it->get_to(value.int_16_field);
   }
   if (auto it = j.find("uint16Field"); it != j.end()) {
-    it->get_to(value.uint16_field);
+    it->get_to(value.uint_16_field);
   }
   if (auto it = j.find("int32Field"); it != j.end()) {
-    it->get_to(value.int32_field);
+    it->get_to(value.int_32_field);
   }
   if (auto it = j.find("uint32Field"); it != j.end()) {
-    it->get_to(value.uint32_field);
+    it->get_to(value.uint_32_field);
   }
   if (auto it = j.find("int64Field"); it != j.end()) {
-    it->get_to(value.int64_field);
+    it->get_to(value.int_64_field);
   }
   if (auto it = j.find("uint64Field"); it != j.end()) {
-    it->get_to(value.uint64_field);
+    it->get_to(value.uint_64_field);
   }
   if (auto it = j.find("sizeField"); it != j.end()) {
     it->get_to(value.size_field);
   }
   if (auto it = j.find("float32Field"); it != j.end()) {
-    it->get_to(value.float32_field);
+    it->get_to(value.float_32_field);
   }
   if (auto it = j.find("float64Field"); it != j.end()) {
-    it->get_to(value.float64_field);
+    it->get_to(value.float_64_field);
   }
   if (auto it = j.find("complexfloat32Field"); it != j.end()) {
-    it->get_to(value.complexfloat32_field);
+    it->get_to(value.complexfloat_32_field);
   }
   if (auto it = j.find("complexfloat64Field"); it != j.end()) {
-    it->get_to(value.complexfloat64_field);
+    it->get_to(value.complexfloat_64_field);
   }
   if (auto it = j.find("dateField"); it != j.end()) {
     it->get_to(value.date_field);
@@ -744,20 +744,20 @@ void to_json(ordered_json& j, test_model::RecordWithArrays const& value) {
   if (yardl::ndjson::ShouldSerializeFieldValue(value.default_array_with_empty_dimension)) {
     j.push_back({"defaultArrayWithEmptyDimension", value.default_array_with_empty_dimension});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank1_array)) {
-    j.push_back({"rank1Array", value.rank1_array});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_1_array)) {
+    j.push_back({"rank1Array", value.rank_1_array});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank2_array)) {
-    j.push_back({"rank2Array", value.rank2_array});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_2_array)) {
+    j.push_back({"rank2Array", value.rank_2_array});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank2_array_with_named_dimensions)) {
-    j.push_back({"rank2ArrayWithNamedDimensions", value.rank2_array_with_named_dimensions});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_2_array_with_named_dimensions)) {
+    j.push_back({"rank2ArrayWithNamedDimensions", value.rank_2_array_with_named_dimensions});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank2_fixed_array)) {
-    j.push_back({"rank2FixedArray", value.rank2_fixed_array});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_2_fixed_array)) {
+    j.push_back({"rank2FixedArray", value.rank_2_fixed_array});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank2_fixed_array_with_named_dimensions)) {
-    j.push_back({"rank2FixedArrayWithNamedDimensions", value.rank2_fixed_array_with_named_dimensions});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_2_fixed_array_with_named_dimensions)) {
+    j.push_back({"rank2FixedArrayWithNamedDimensions", value.rank_2_fixed_array_with_named_dimensions});
   }
   if (yardl::ndjson::ShouldSerializeFieldValue(value.dynamic_array)) {
     j.push_back({"dynamicArray", value.dynamic_array});
@@ -775,19 +775,19 @@ void from_json(ordered_json const& j, test_model::RecordWithArrays& value) {
     it->get_to(value.default_array_with_empty_dimension);
   }
   if (auto it = j.find("rank1Array"); it != j.end()) {
-    it->get_to(value.rank1_array);
+    it->get_to(value.rank_1_array);
   }
   if (auto it = j.find("rank2Array"); it != j.end()) {
-    it->get_to(value.rank2_array);
+    it->get_to(value.rank_2_array);
   }
   if (auto it = j.find("rank2ArrayWithNamedDimensions"); it != j.end()) {
-    it->get_to(value.rank2_array_with_named_dimensions);
+    it->get_to(value.rank_2_array_with_named_dimensions);
   }
   if (auto it = j.find("rank2FixedArray"); it != j.end()) {
-    it->get_to(value.rank2_fixed_array);
+    it->get_to(value.rank_2_fixed_array);
   }
   if (auto it = j.find("rank2FixedArrayWithNamedDimensions"); it != j.end()) {
-    it->get_to(value.rank2_fixed_array_with_named_dimensions);
+    it->get_to(value.rank_2_fixed_array_with_named_dimensions);
   }
   if (auto it = j.find("dynamicArray"); it != j.end()) {
     it->get_to(value.dynamic_array);
@@ -805,20 +805,20 @@ void to_json(ordered_json& j, test_model::RecordWithArraysSimpleSyntax const& va
   if (yardl::ndjson::ShouldSerializeFieldValue(value.default_array_with_empty_dimension)) {
     j.push_back({"defaultArrayWithEmptyDimension", value.default_array_with_empty_dimension});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank1_array)) {
-    j.push_back({"rank1Array", value.rank1_array});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_1_array)) {
+    j.push_back({"rank1Array", value.rank_1_array});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank2_array)) {
-    j.push_back({"rank2Array", value.rank2_array});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_2_array)) {
+    j.push_back({"rank2Array", value.rank_2_array});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank2_array_with_named_dimensions)) {
-    j.push_back({"rank2ArrayWithNamedDimensions", value.rank2_array_with_named_dimensions});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_2_array_with_named_dimensions)) {
+    j.push_back({"rank2ArrayWithNamedDimensions", value.rank_2_array_with_named_dimensions});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank2_fixed_array)) {
-    j.push_back({"rank2FixedArray", value.rank2_fixed_array});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_2_fixed_array)) {
+    j.push_back({"rank2FixedArray", value.rank_2_fixed_array});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank2_fixed_array_with_named_dimensions)) {
-    j.push_back({"rank2FixedArrayWithNamedDimensions", value.rank2_fixed_array_with_named_dimensions});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.rank_2_fixed_array_with_named_dimensions)) {
+    j.push_back({"rank2FixedArrayWithNamedDimensions", value.rank_2_fixed_array_with_named_dimensions});
   }
   if (yardl::ndjson::ShouldSerializeFieldValue(value.dynamic_array)) {
     j.push_back({"dynamicArray", value.dynamic_array});
@@ -836,19 +836,19 @@ void from_json(ordered_json const& j, test_model::RecordWithArraysSimpleSyntax& 
     it->get_to(value.default_array_with_empty_dimension);
   }
   if (auto it = j.find("rank1Array"); it != j.end()) {
-    it->get_to(value.rank1_array);
+    it->get_to(value.rank_1_array);
   }
   if (auto it = j.find("rank2Array"); it != j.end()) {
-    it->get_to(value.rank2_array);
+    it->get_to(value.rank_2_array);
   }
   if (auto it = j.find("rank2ArrayWithNamedDimensions"); it != j.end()) {
-    it->get_to(value.rank2_array_with_named_dimensions);
+    it->get_to(value.rank_2_array_with_named_dimensions);
   }
   if (auto it = j.find("rank2FixedArray"); it != j.end()) {
-    it->get_to(value.rank2_fixed_array);
+    it->get_to(value.rank_2_fixed_array);
   }
   if (auto it = j.find("rank2FixedArrayWithNamedDimensions"); it != j.end()) {
-    it->get_to(value.rank2_fixed_array_with_named_dimensions);
+    it->get_to(value.rank_2_fixed_array_with_named_dimensions);
   }
   if (auto it = j.find("dynamicArray"); it != j.end()) {
     it->get_to(value.dynamic_array);
@@ -1380,33 +1380,33 @@ void from_json(ordered_json const& j, test_model::TextFormat& value) {
 template <typename T1, typename T2>
 void to_json(ordered_json& j, test_model::GenericRecord<T1, T2> const& value) {
   j = ordered_json::object();
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.scalar1)) {
-    j.push_back({"scalar1", value.scalar1});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.scalar_1)) {
+    j.push_back({"scalar1", value.scalar_1});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.scalar2)) {
-    j.push_back({"scalar2", value.scalar2});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.scalar_2)) {
+    j.push_back({"scalar2", value.scalar_2});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.vector1)) {
-    j.push_back({"vector1", value.vector1});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.vector_1)) {
+    j.push_back({"vector1", value.vector_1});
   }
-  if (yardl::ndjson::ShouldSerializeFieldValue(value.image2)) {
-    j.push_back({"image2", value.image2});
+  if (yardl::ndjson::ShouldSerializeFieldValue(value.image_2)) {
+    j.push_back({"image2", value.image_2});
   }
 }
 
 template <typename T1, typename T2>
 void from_json(ordered_json const& j, test_model::GenericRecord<T1, T2>& value) {
   if (auto it = j.find("scalar1"); it != j.end()) {
-    it->get_to(value.scalar1);
+    it->get_to(value.scalar_1);
   }
   if (auto it = j.find("scalar2"); it != j.end()) {
-    it->get_to(value.scalar2);
+    it->get_to(value.scalar_2);
   }
   if (auto it = j.find("vector1"); it != j.end()) {
-    it->get_to(value.vector1);
+    it->get_to(value.vector_1);
   }
   if (auto it = j.find("image2"); it != j.end()) {
-    it->get_to(value.image2);
+    it->get_to(value.image_2);
   }
 }
 

--- a/cpp/test/generated/protocols.cc
+++ b/cpp/test/generated/protocols.cc
@@ -141,10 +141,10 @@ void BenchmarkFloat256x256ReaderBase::Close() {
 
   CloseImpl();
 }
-void BenchmarkFloat256x256ReaderBase::CopyTo(BenchmarkFloat256x256WriterBase& writer, size_t float256x256_buffer_size) {
-  if (float256x256_buffer_size > 1) {
+void BenchmarkFloat256x256ReaderBase::CopyTo(BenchmarkFloat256x256WriterBase& writer, size_t float_256x_256_buffer_size) {
+  if (float_256x_256_buffer_size > 1) {
     std::vector<yardl::FixedNDArray<float, 256, 256>> values;
-    values.reserve(float256x256_buffer_size);
+    values.reserve(float_256x_256_buffer_size);
     while(ReadFloat256x256(values)) {
       writer.WriteFloat256x256(values);
     }
@@ -4655,7 +4655,7 @@ void AliasesReaderBase::Close() {
 
   CloseImpl();
 }
-void AliasesReaderBase::CopyTo(AliasesWriterBase& writer, size_t stream_of_aliased_generic_union2_buffer_size) {
+void AliasesReaderBase::CopyTo(AliasesWriterBase& writer, size_t stream_of_aliased_generic_union_2_buffer_size) {
   {
     test_model::AliasedString value;
     ReadAliasedString(value);
@@ -4701,9 +4701,9 @@ void AliasesReaderBase::CopyTo(AliasesWriterBase& writer, size_t stream_of_alias
     ReadAliasedGenericFixedVector(value);
     writer.WriteAliasedGenericFixedVector(value);
   }
-  if (stream_of_aliased_generic_union2_buffer_size > 1) {
+  if (stream_of_aliased_generic_union_2_buffer_size > 1) {
     std::vector<test_model::AliasedGenericUnion2<test_model::AliasedString, test_model::AliasedEnum>> values;
-    values.reserve(stream_of_aliased_generic_union2_buffer_size);
+    values.reserve(stream_of_aliased_generic_union_2_buffer_size);
     while(ReadStreamOfAliasedGenericUnion2(values)) {
       writer.WriteStreamOfAliasedGenericUnion2(values);
     }

--- a/cpp/test/generated/protocols.h
+++ b/cpp/test/generated/protocols.h
@@ -52,7 +52,7 @@ class BenchmarkFloat256x256ReaderBase {
   // Optionaly close this writer before destructing. Validates that all steps were completely read.
   void Close();
 
-  void CopyTo(BenchmarkFloat256x256WriterBase& writer, size_t float256x256_buffer_size = 1);
+  void CopyTo(BenchmarkFloat256x256WriterBase& writer, size_t float_256x_256_buffer_size = 1);
 
   virtual ~BenchmarkFloat256x256ReaderBase() = default;
 
@@ -1933,7 +1933,7 @@ class AliasesReaderBase {
   // Optionaly close this writer before destructing. Validates that all steps were completely read.
   void Close();
 
-  void CopyTo(AliasesWriterBase& writer, size_t stream_of_aliased_generic_union2_buffer_size = 1);
+  void CopyTo(AliasesWriterBase& writer, size_t stream_of_aliased_generic_union_2_buffer_size = 1);
 
   virtual ~AliasesReaderBase() = default;
 

--- a/cpp/test/generated/types.h
+++ b/cpp/test/generated/types.h
@@ -81,38 +81,38 @@ struct SimpleRecord {
 
 struct RecordWithPrimitives {
   bool bool_field{};
-  int8_t int8_field{};
-  uint8_t uint8_field{};
-  int16_t int16_field{};
-  uint16_t uint16_field{};
-  int32_t int32_field{};
-  uint32_t uint32_field{};
-  int64_t int64_field{};
-  uint64_t uint64_field{};
+  int8_t int_8_field{};
+  uint8_t uint_8_field{};
+  int16_t int_16_field{};
+  uint16_t uint_16_field{};
+  int32_t int_32_field{};
+  uint32_t uint_32_field{};
+  int64_t int_64_field{};
+  uint64_t uint_64_field{};
   yardl::Size size_field{};
-  float float32_field{};
-  double float64_field{};
-  std::complex<float> complexfloat32_field{};
-  std::complex<double> complexfloat64_field{};
+  float float_32_field{};
+  double float_64_field{};
+  std::complex<float> complexfloat_32_field{};
+  std::complex<double> complexfloat_64_field{};
   yardl::Date date_field{};
   yardl::Time time_field{};
   yardl::DateTime datetime_field{};
 
   bool operator==(const RecordWithPrimitives& other) const {
     return bool_field == other.bool_field &&
-      int8_field == other.int8_field &&
-      uint8_field == other.uint8_field &&
-      int16_field == other.int16_field &&
-      uint16_field == other.uint16_field &&
-      int32_field == other.int32_field &&
-      uint32_field == other.uint32_field &&
-      int64_field == other.int64_field &&
-      uint64_field == other.uint64_field &&
+      int_8_field == other.int_8_field &&
+      uint_8_field == other.uint_8_field &&
+      int_16_field == other.int_16_field &&
+      uint_16_field == other.uint_16_field &&
+      int_32_field == other.int_32_field &&
+      uint_32_field == other.uint_32_field &&
+      int_64_field == other.int_64_field &&
+      uint_64_field == other.uint_64_field &&
       size_field == other.size_field &&
-      float32_field == other.float32_field &&
-      float64_field == other.float64_field &&
-      complexfloat32_field == other.complexfloat32_field &&
-      complexfloat64_field == other.complexfloat64_field &&
+      float_32_field == other.float_32_field &&
+      float_64_field == other.float_64_field &&
+      complexfloat_32_field == other.complexfloat_32_field &&
+      complexfloat_64_field == other.complexfloat_64_field &&
       date_field == other.date_field &&
       time_field == other.time_field &&
       datetime_field == other.datetime_field;
@@ -184,22 +184,22 @@ struct RecordWithVectors {
 struct RecordWithArrays {
   yardl::DynamicNDArray<int32_t> default_array{};
   yardl::DynamicNDArray<int32_t> default_array_with_empty_dimension{};
-  yardl::NDArray<int32_t, 1> rank1_array{};
-  yardl::NDArray<int32_t, 2> rank2_array{};
-  yardl::NDArray<int32_t, 2> rank2_array_with_named_dimensions{};
-  yardl::FixedNDArray<int32_t, 3, 4> rank2_fixed_array{};
-  yardl::FixedNDArray<int32_t, 3, 4> rank2_fixed_array_with_named_dimensions{};
+  yardl::NDArray<int32_t, 1> rank_1_array{};
+  yardl::NDArray<int32_t, 2> rank_2_array{};
+  yardl::NDArray<int32_t, 2> rank_2_array_with_named_dimensions{};
+  yardl::FixedNDArray<int32_t, 3, 4> rank_2_fixed_array{};
+  yardl::FixedNDArray<int32_t, 3, 4> rank_2_fixed_array_with_named_dimensions{};
   yardl::DynamicNDArray<int32_t> dynamic_array{};
   yardl::FixedNDArray<std::array<int32_t, 4>, 5> array_of_vectors{};
 
   bool operator==(const RecordWithArrays& other) const {
     return default_array == other.default_array &&
       default_array_with_empty_dimension == other.default_array_with_empty_dimension &&
-      rank1_array == other.rank1_array &&
-      rank2_array == other.rank2_array &&
-      rank2_array_with_named_dimensions == other.rank2_array_with_named_dimensions &&
-      rank2_fixed_array == other.rank2_fixed_array &&
-      rank2_fixed_array_with_named_dimensions == other.rank2_fixed_array_with_named_dimensions &&
+      rank_1_array == other.rank_1_array &&
+      rank_2_array == other.rank_2_array &&
+      rank_2_array_with_named_dimensions == other.rank_2_array_with_named_dimensions &&
+      rank_2_fixed_array == other.rank_2_fixed_array &&
+      rank_2_fixed_array_with_named_dimensions == other.rank_2_fixed_array_with_named_dimensions &&
       dynamic_array == other.dynamic_array &&
       array_of_vectors == other.array_of_vectors;
   }
@@ -212,22 +212,22 @@ struct RecordWithArrays {
 struct RecordWithArraysSimpleSyntax {
   yardl::DynamicNDArray<int32_t> default_array{};
   yardl::DynamicNDArray<int32_t> default_array_with_empty_dimension{};
-  yardl::NDArray<int32_t, 1> rank1_array{};
-  yardl::NDArray<int32_t, 2> rank2_array{};
-  yardl::NDArray<int32_t, 2> rank2_array_with_named_dimensions{};
-  yardl::FixedNDArray<int32_t, 3, 4> rank2_fixed_array{};
-  yardl::FixedNDArray<int32_t, 3, 4> rank2_fixed_array_with_named_dimensions{};
+  yardl::NDArray<int32_t, 1> rank_1_array{};
+  yardl::NDArray<int32_t, 2> rank_2_array{};
+  yardl::NDArray<int32_t, 2> rank_2_array_with_named_dimensions{};
+  yardl::FixedNDArray<int32_t, 3, 4> rank_2_fixed_array{};
+  yardl::FixedNDArray<int32_t, 3, 4> rank_2_fixed_array_with_named_dimensions{};
   yardl::DynamicNDArray<int32_t> dynamic_array{};
   yardl::FixedNDArray<std::array<int32_t, 4>, 5> array_of_vectors{};
 
   bool operator==(const RecordWithArraysSimpleSyntax& other) const {
     return default_array == other.default_array &&
       default_array_with_empty_dimension == other.default_array_with_empty_dimension &&
-      rank1_array == other.rank1_array &&
-      rank2_array == other.rank2_array &&
-      rank2_array_with_named_dimensions == other.rank2_array_with_named_dimensions &&
-      rank2_fixed_array == other.rank2_fixed_array &&
-      rank2_fixed_array_with_named_dimensions == other.rank2_fixed_array_with_named_dimensions &&
+      rank_1_array == other.rank_1_array &&
+      rank_2_array == other.rank_2_array &&
+      rank_2_array_with_named_dimensions == other.rank_2_array_with_named_dimensions &&
+      rank_2_fixed_array == other.rank_2_fixed_array &&
+      rank_2_fixed_array_with_named_dimensions == other.rank_2_fixed_array_with_named_dimensions &&
       dynamic_array == other.dynamic_array &&
       array_of_vectors == other.array_of_vectors;
   }
@@ -437,16 +437,16 @@ using Image = yardl::NDArray<T, 2>;
 
 template <typename T1, typename T2>
 struct GenericRecord {
-  T1 scalar1{};
-  T2 scalar2{};
-  std::vector<T1> vector1{};
-  test_model::Image<T2> image2{};
+  T1 scalar_1{};
+  T2 scalar_2{};
+  std::vector<T1> vector_1{};
+  test_model::Image<T2> image_2{};
 
   bool operator==(const GenericRecord& other) const {
-    return scalar1 == other.scalar1 &&
-      scalar2 == other.scalar2 &&
-      vector1 == other.vector1 &&
-      image2 == other.image2;
+    return scalar_1 == other.scalar_1 &&
+      scalar_2 == other.scalar_2 &&
+      vector_1 == other.vector_1 &&
+      image_2 == other.image_2;
   }
 
   bool operator!=(const GenericRecord& other) const {

--- a/cpp/test/roundtrip_test.cc
+++ b/cpp/test/roundtrip_test.cc
@@ -40,19 +40,19 @@ TEST_P(RoundTripTests, Scalars) {
 
   RecordWithPrimitives rec;
   rec.bool_field = true;
-  rec.int8_field = -33;
-  rec.uint8_field = 33;
-  rec.uint16_field = -44;
-  rec.uint16_field = 44;
-  rec.int32_field = -55;
-  rec.uint32_field = 55;
-  rec.int64_field = -66;
-  rec.uint64_field = 66;
+  rec.int_8_field = -33;
+  rec.uint_8_field = 33;
+  rec.uint_16_field = -44;
+  rec.uint_16_field = 44;
+  rec.int_32_field = -55;
+  rec.uint_32_field = 55;
+  rec.int_64_field = -66;
+  rec.uint_64_field = 66;
   rec.size_field = UINT64_MAX;
-  rec.float32_field = 4290.39;
-  rec.float64_field = 2234290.39;
-  rec.complexfloat32_field = {1.3, 2.2};
-  rec.complexfloat64_field = {-2.4, 999.3};
+  rec.float_32_field = 4290.39;
+  rec.float_64_field = 2234290.39;
+  rec.complexfloat_32_field = {1.3, 2.2};
+  rec.complexfloat_64_field = {-2.4, 999.3};
   rec.date_field = Date(year{2022} / 9 / 8);
   rec.time_field = std::chrono::hours(10) + std::chrono::minutes(50) +
                    std::chrono::seconds(25) + std::chrono::milliseconds(777);

--- a/tooling/internal/formatting/formatting.go
+++ b/tooling/internal/formatting/formatting.go
@@ -112,11 +112,7 @@ func ToPascalCase(s string) string {
 	return b.String()
 }
 
-// Copied from the from the VSCode "transform to snake case" command implementation.
-// Note that their implementation has since been changed to use two regexes instead of using
-// lookbehinds and lookaheads, but the implementation here is actually about two orders of magnitude faster.
-// Note that in order to use lookbehinds, we need to use the regexp2 package.
-var snakeCaseRegex = regexp2.MustCompile(`(?<=\p{Ll})(\p{Lu})|(?<!\b|_)(\p{Lu})(?=\p{Ll})`, regexp2.ExplicitCapture)
+var snakeCaseRegex = regexp2.MustCompile(`((?<=\p{Ll})(\p{Lu}))|(?<!(\b|_)\p{Ll})((?<=\p{Ll})(\d))|(?<!\b|_)(\p{Lu})(?=\p{Ll})`, regexp2.ExplicitCapture)
 
 func ToSnakeCase(str string) string {
 	s, err := snakeCaseRegex.Replace(str, `_$&`, -1, -1)

--- a/tooling/internal/formatting/formatting_test.go
+++ b/tooling/internal/formatting/formatting_test.go
@@ -64,9 +64,18 @@ func TestPascalOrCamelToSnakeCase(t *testing.T) {
 		{"Capital_Snake_Case", "capital_snake_case"},
 		{"YAML", "yaml"},
 		{"YAML2", "yaml2"},
-		{"yaml2Spec", "yaml2_spec"},
+		{"yaml2Spec", "yaml_2_spec"},
 		{"YAML2Spec", "yaml2_spec"},
 		{"YAML42Spec", "yaml42_spec"},
+		{"Super42", "super_42"},
+		{"Super42car", "super_42car"},
+		{"Super42Car", "super_42_car"},
+		{"myM1Processor", "my_m1_processor"},
+		{"myM1", "my_m1"},
+		{"m1", "m1"},
+		{"myMP3", "my_mp3"},
+		{"snake3C3ase", "snake_3c3ase"},
+		{"kspaceEncodeStep1", "kspace_encode_step_1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.intput, func(t *testing.T) {


### PR DESCRIPTION
Changing the tokenization used to convert PascalCased and camelCased identifiers to snake_case.

In particular, numbers will be separated by an underscore, unless preceded by an uppercase. So `kspaceEncodeStep1` becomes `kspace_encode_step_1` instead of `kspace_encode_step1`.