### PR TITLE
Fix favicon on documentation website

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vitepress";
 
+const base = "/yardl"
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Yardl",
   description: "Yardl Documentation",
-  head: [["link", { rel: "icon", href: "/favicon.ico" }]],
+  head: [["link", { rel: "icon", href: `${base}/favicon.ico` }]],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
@@ -122,6 +123,6 @@ export default defineConfig({
       },
     },
   },
-  base: "/yardl/",
+  base: base,
   srcExclude: ["README.md"],
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
 
+titleTemplate: false
+
 hero:
   name: Yardl
   text: Define and Stream Instrument Data


### PR DESCRIPTION
The link to the favicon.ico file was broken on the published website.