### PR TITLE
Python codegen: deduplicate union type parameters

### DIFF
--- a/cpp/test/generated/binary/protocols.cc
+++ b/cpp/test/generated/binary/protocols.cc
@@ -2260,6 +2260,26 @@ template<typename A, yardl::binary::Reader<A> ReadA, typename B, yardl::binary::
   yardl::binary::ReadMap<std::string, std::string, yardl::binary::ReadString, yardl::binary::ReadString>(stream, value.map_field);
 }
 
+template<typename T, yardl::binary::Writer<T> WriteT>
+[[maybe_unused]] void WriteGenericUnionWithRepeatedTypeParameters(yardl::binary::CodedOutputStream& stream, test_model::GenericUnionWithRepeatedTypeParameters<T> const& value) {
+  if constexpr (yardl::binary::IsTriviallySerializable<test_model::GenericUnionWithRepeatedTypeParameters<T>>::value) {
+    yardl::binary::WriteTriviallySerializable(stream, value);
+    return;
+  }
+
+  WriteUnion<T, WriteT, std::vector<T>, yardl::binary::WriteVector<T, WriteT>, yardl::DynamicNDArray<T>, yardl::binary::WriteDynamicNDArray<T, WriteT>>(stream, value);
+}
+
+template<typename T, yardl::binary::Reader<T> ReadT>
+[[maybe_unused]] void ReadGenericUnionWithRepeatedTypeParameters(yardl::binary::CodedInputStream& stream, test_model::GenericUnionWithRepeatedTypeParameters<T>& value) {
+  if constexpr (yardl::binary::IsTriviallySerializable<test_model::GenericUnionWithRepeatedTypeParameters<T>>::value) {
+    yardl::binary::ReadTriviallySerializable(stream, value);
+    return;
+  }
+
+  ReadUnion<T, ReadT, std::vector<T>, yardl::binary::ReadVector<T, ReadT>, yardl::DynamicNDArray<T>, yardl::binary::ReadDynamicNDArray<T, ReadT>>(stream, value);
+}
+
 template<typename T, yardl::binary::Writer<T> WriteT, typename U, yardl::binary::Writer<U> WriteU, typename V, yardl::binary::Writer<V> WriteV>
 [[maybe_unused]] void WriteGenericUnion3(yardl::binary::CodedOutputStream& stream, test_model::GenericUnion3<T, U, V> const& value) {
   if constexpr (yardl::binary::IsTriviallySerializable<test_model::GenericUnion3<T, U, V>>::value) {

--- a/cpp/test/generated/model.json
+++ b/cpp/test/generated/model.json
@@ -3559,6 +3559,39 @@
         },
         {
           "alias": {
+            "name": "GenericUnionWithRepeatedTypeParameters",
+            "typeParameters": [
+              "T"
+            ],
+            "type": [
+              {
+                "tag": "t",
+                "explicitTag": true,
+                "type": "T"
+              },
+              {
+                "tag": "tv",
+                "explicitTag": true,
+                "type": {
+                  "vector": {
+                    "items": "T"
+                  }
+                }
+              },
+              {
+                "tag": "ta",
+                "explicitTag": true,
+                "type": {
+                  "array": {
+                    "items": "T"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "alias": {
             "name": "GenericUnion3",
             "typeParameters": [
               "T",

--- a/cpp/test/generated/ndjson/protocols.cc
+++ b/cpp/test/generated/ndjson/protocols.cc
@@ -483,6 +483,42 @@ struct adl_serializer<std::variant<std::string, float>> {
   }
 };
 
+template <typename T1>
+struct adl_serializer<std::variant<T1, std::vector<T1>, yardl::DynamicNDArray<T1>>> {
+  static void to_json(ordered_json& j, std::variant<T1, std::vector<T1>, yardl::DynamicNDArray<T1>> const& value) {
+    switch (value.index()) {
+      case 0:
+        j = ordered_json{ {"t", std::get<T1>(value)} };
+        break;
+      case 1:
+        j = ordered_json{ {"tv", std::get<std::vector<T1>>(value)} };
+        break;
+      case 2:
+        j = ordered_json{ {"ta", std::get<yardl::DynamicNDArray<T1>>(value)} };
+        break;
+      default:
+        throw std::runtime_error("Invalid union value");
+    }
+  }
+
+  static void from_json(ordered_json const& j, std::variant<T1, std::vector<T1>, yardl::DynamicNDArray<T1>>& value) {
+    auto it = j.begin();
+    std::string tag = it.key();
+    if (tag == "t") {
+      value = it.value().get<T1>();
+      return;
+    }
+    if (tag == "tv") {
+      value = it.value().get<std::vector<T1>>();
+      return;
+    }
+    if (tag == "ta") {
+      value = it.value().get<yardl::DynamicNDArray<T1>>();
+      return;
+    }
+  }
+};
+
 template <typename T1, typename T2, typename T3>
 struct adl_serializer<std::variant<T1, T2, T3>> {
   static void to_json(ordered_json& j, std::variant<T1, T2, T3> const& value) {

--- a/cpp/test/generated/types.h
+++ b/cpp/test/generated/types.h
@@ -1304,6 +1304,9 @@ struct RecordWithComputedFields {
   }
 };
 
+template <typename T>
+using GenericUnionWithRepeatedTypeParameters = std::variant<T, std::vector<T>, yardl::DynamicNDArray<T>>;
+
 template <typename T, typename U, typename V>
 using GenericUnion3 = std::variant<T, U, V>;
 

--- a/models/test/unittests.yml
+++ b/models/test/unittests.yml
@@ -640,6 +640,11 @@ ProtocolWithComputedFields: !protocol
     recordWithComputedFields: RecordWithComputedFields
 
 
+GenericUnionWithRepeatedTypeParameters<T>: !union
+  t: T
+  tv: T*
+  ta: T[]
+
 GenericUnion3<T, U, V>: [T, U, V]
 GenericUnion3Alternate<U, V, W>: [U, V, W]
 

--- a/python/test_model/__init__.py
+++ b/python/test_model/__init__.py
@@ -47,6 +47,7 @@ from .types import (
     GenericRecord,
     GenericUnion3,
     GenericUnion3Alternate,
+    GenericUnionWithRepeatedTypeParameters,
     Image,
     ImageFloatOrImageDouble,
     Int32OrFloat32,

--- a/python/test_model/types.py
+++ b/python/test_model/types.py
@@ -1686,6 +1686,19 @@ class RecordWithComputedFields:
         return f"RecordWithComputedFields(arrayField={repr(self.array_field)}, arrayFieldMapDimensions={repr(self.array_field_map_dimensions)}, dynamicArrayField={repr(self.dynamic_array_field)}, fixedArrayField={repr(self.fixed_array_field)}, intField={repr(self.int_field)}, int8Field={repr(self.int8_field)}, uint8Field={repr(self.uint8_field)}, int16Field={repr(self.int16_field)}, uint16Field={repr(self.uint16_field)}, uint32Field={repr(self.uint32_field)}, int64Field={repr(self.int64_field)}, uint64Field={repr(self.uint64_field)}, sizeField={repr(self.size_field)}, float32Field={repr(self.float32_field)}, float64Field={repr(self.float64_field)}, complexfloat32Field={repr(self.complexfloat32_field)}, complexfloat64Field={repr(self.complexfloat64_field)}, stringField={repr(self.string_field)}, tupleField={repr(self.tuple_field)}, vectorField={repr(self.vector_field)}, vectorOfVectorsField={repr(self.vector_of_vectors_field)}, fixedVectorField={repr(self.fixed_vector_field)}, optionalNamedArray={repr(self.optional_named_array)}, intFloatUnion={repr(self.int_float_union)}, nullableIntFloatUnion={repr(self.nullable_int_float_union)}, unionWithNestedGenericUnion={repr(self.union_with_nested_generic_union)}, mapField={repr(self.map_field)})"
 
 
+class GenericUnionWithRepeatedTypeParameters(typing.Generic[T, T_NP]):
+    T: type["GenericUnionWithRepeatedTypeParametersUnionCase[T, T_NP, T]"]
+    Tv: type["GenericUnionWithRepeatedTypeParametersUnionCase[T, T_NP, list[T]]"]
+    Ta: type["GenericUnionWithRepeatedTypeParametersUnionCase[T, T_NP, npt.NDArray[T_NP]]"]
+
+class GenericUnionWithRepeatedTypeParametersUnionCase(GenericUnionWithRepeatedTypeParameters[T, T_NP], yardl.UnionCase[_T]):
+    pass
+
+GenericUnionWithRepeatedTypeParameters.T = type("GenericUnionWithRepeatedTypeParameters.T", (GenericUnionWithRepeatedTypeParametersUnionCase,), {"index": 0, "tag": "t"})
+GenericUnionWithRepeatedTypeParameters.Tv = type("GenericUnionWithRepeatedTypeParameters.Tv", (GenericUnionWithRepeatedTypeParametersUnionCase,), {"index": 1, "tag": "tv"})
+GenericUnionWithRepeatedTypeParameters.Ta = type("GenericUnionWithRepeatedTypeParameters.Ta", (GenericUnionWithRepeatedTypeParametersUnionCase,), {"index": 2, "tag": "ta"})
+del GenericUnionWithRepeatedTypeParametersUnionCase
+
 class GenericUnion3(typing.Generic[T, U, V]):
     T: type["GenericUnion3UnionCase[T, U, V, T]"]
     U: type["GenericUnion3UnionCase[T, U, V, U]"]
@@ -1925,6 +1938,7 @@ def _mk_get_dtype():
     dtype_map.setdefault(Int32OrFloat32, np.dtype(np.object_))
     dtype_map.setdefault(IntOrGenericRecordWithComputedFields, np.dtype(np.object_))
     dtype_map.setdefault(RecordWithComputedFields, np.dtype([('array_field', np.dtype(np.object_)), ('array_field_map_dimensions', np.dtype(np.object_)), ('dynamic_array_field', np.dtype(np.object_)), ('fixed_array_field', np.dtype(np.int32), (3, 4,)), ('int_field', np.dtype(np.int32)), ('int8_field', np.dtype(np.int8)), ('uint8_field', np.dtype(np.uint8)), ('int16_field', np.dtype(np.int16)), ('uint16_field', np.dtype(np.uint16)), ('uint32_field', np.dtype(np.uint32)), ('int64_field', np.dtype(np.int64)), ('uint64_field', np.dtype(np.uint64)), ('size_field', np.dtype(np.uint64)), ('float32_field', np.dtype(np.float32)), ('float64_field', np.dtype(np.float64)), ('complexfloat32_field', np.dtype(np.complex64)), ('complexfloat64_field', np.dtype(np.complex128)), ('string_field', np.dtype(np.object_)), ('tuple_field', get_dtype(types.GenericAlias(MyTuple, (yardl.Int32, yardl.Int32,)))), ('vector_field', np.dtype(np.object_)), ('vector_of_vectors_field', np.dtype(np.object_)), ('fixed_vector_field', np.dtype(np.int32), (3,)), ('optional_named_array', np.dtype([('has_value', np.dtype(np.bool_)), ('value', get_dtype(NamedNDArray))], align=True)), ('int_float_union', np.dtype(np.object_)), ('nullable_int_float_union', np.dtype(np.object_)), ('union_with_nested_generic_union', np.dtype(np.object_)), ('map_field', np.dtype(np.object_))], align=True))
+    dtype_map.setdefault(GenericUnionWithRepeatedTypeParameters, lambda type_args: np.dtype(np.object_))
     dtype_map.setdefault(GenericUnion3, lambda type_args: np.dtype(np.object_))
     dtype_map.setdefault(GenericUnion3Alternate, lambda type_args: np.dtype(np.object_))
     dtype_map.setdefault(RecordNotUsedInProtocol, np.dtype([('u1', get_dtype(types.GenericAlias(GenericUnion3, (yardl.Int32, yardl.Float32, str,)))), ('u2', get_dtype(types.GenericAlias(GenericUnion3Alternate, (yardl.Int32, yardl.Float32, str,))))], align=True))

--- a/tooling/internal/python/common/common.go
+++ b/tooling/internal/python/common/common.go
@@ -432,6 +432,7 @@ func GetOpenGenericTypeParameters(node dsl.Node) string {
 					return
 				}
 			}
+			res = append(res, t)
 			paramStrings = appendGenericTypeParameterUses(paramStrings, t)
 		case *dsl.SimpleType:
 			if gtp, ok := t.ResolvedDefinition.(*dsl.GenericTypeParameter); ok {
@@ -442,6 +443,7 @@ func GetOpenGenericTypeParameters(node dsl.Node) string {
 					}
 				}
 				if !found {
+					res = append(res, gtp)
 					paramStrings = appendGenericTypeParameterUses(paramStrings, gtp)
 				}
 			}


### PR DESCRIPTION
Fixes #111 