### PR TITLE
Temporarily disable macos test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
 
   smoketestMac:
     name: Run smoke test on macOS
+    if: false # Disabling until this is fixed: https://github.com/Homebrew/homebrew-core/issues/159691
     runs-on: macos-latest
     needs: buildBinaries
     steps:


### PR DESCRIPTION
Installing HDF5 using homebrew appears to be broken at the moment, at least on GitHub runners. See https://github.com/Homebrew/homebrew-core/issues/159691.

Disabling the macos tests for now.