### PR TITLE
Fix publish regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     needs:
       - validate
       - smoketestWindows
-      - smoketestMac
+      # - smoketestMac # Disabling until this is fixed: https://github.com/Homebrew/homebrew-core/issues/159691
       - noticeCheck
 
     runs-on: ubuntu-latest
@@ -212,7 +212,7 @@ jobs:
     needs:
       - validate
       - smoketestWindows
-      - smoketestMac
+      # - smoketestMac # Disabling until this is fixed: https://github.com/Homebrew/homebrew-core/issues/159691
       - noticeCheck
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Publishing docs and releases was broken when I disabled the macos smoke tests in #129 