### PR TITLE
Updating persmissions for creating GitHub releases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,10 @@ jobs:
       # - smoketestMac # Disabling until this is fixed: https://github.com/Homebrew/homebrew-core/issues/159691
       - noticeCheck
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Default GitHub actions permissions were recently changed and we now need to request permisssions to create GitHub releases in the `release` job.