### PR TITLE
Verify that protocols and records are not "empty"

### DIFF
--- a/tooling/pkg/dsl/validation_computed_fields_test.go
+++ b/tooling/pkg/dsl/validation_computed_fields_test.go
@@ -12,6 +12,8 @@ import (
 func TestDuplicateComputedFieldName(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     f: 1
     f: 2`
@@ -22,6 +24,8 @@ X: !record
 func TestUnboundField(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     f: missingField`
 	_, err := parseAndValidate(t, src)
@@ -31,6 +35,8 @@ X: !record
 func TestRecursiveField(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     f: f`
 	_, err := parseAndValidate(t, src)
@@ -40,6 +46,8 @@ X: !record
 func TestCycle(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     a: b
     b: c
@@ -51,6 +59,8 @@ X: !record
 func TestNoCycle(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     a: b
     b: c
@@ -62,6 +72,8 @@ X: !record
 func TestIntTooLarge(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     a: 0xFFFFFFFFFFFFFFFF1`
 	_, err := parseAndValidate(t, src)
@@ -71,6 +83,8 @@ X: !record
 func TestNegativeIntTooLarge(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     a: -0x8000000000000001`
 	_, err := parseAndValidate(t, src)
@@ -94,6 +108,8 @@ Y: !record
 func TestChainedExpressionTargetNotResolved(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     yInt: y.anInt`
 	_, err := parseAndValidate(t, src)
@@ -187,6 +203,8 @@ X: !record
 func TestIndexOnUnresolved(t *testing.T) {
 	src := `
 R: !record
+  fields:
+    unused: int
 X: !record
   fields:
     r: R
@@ -398,6 +416,7 @@ func TestSizeNoArgs(t *testing.T) {
 	src := `
 X: !record
   fields:
+    unused: int
   computedFields:
     vSize: size()`
 	_, err := parseAndValidate(t, src)
@@ -408,6 +427,7 @@ func TestSizeSingleArgWrongType(t *testing.T) {
 	src := `
 X: !record
   fields:
+    unused: int
   computedFields:
     vSize: size(1)`
 	_, err := parseAndValidate(t, src)
@@ -552,6 +572,8 @@ X: !record
 func TestArrayDimensionIndexInvalidArg1Type(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     dimIndeX: dimensionIndex(1, "x")`
 	_, err := parseAndValidate(t, src)
@@ -634,6 +656,8 @@ X: !record
 func TestArrayDimensionCountInvalidArgType(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     dimCount: dimensionCount(1)`
 	_, err := parseAndValidate(t, src)
@@ -643,6 +667,8 @@ X: !record
 func TestSwitchErrorInTarget(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     c:
       !switch missing:
@@ -822,6 +848,8 @@ X: !record
 func TestArithmeticIncompatibleOperands(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     c1: 1 + "2"
 `
@@ -845,6 +873,8 @@ X: !record
 func TestCastToUnrecognizedType(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     c1: 1 as what
 `
@@ -854,6 +884,8 @@ X: !record
 func TestValidCasts(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
   computedFields:
     c1: 1 as int
     c2: 1.1 as int

--- a/tooling/pkg/dsl/validation_test.go
+++ b/tooling/pkg/dsl/validation_test.go
@@ -22,6 +22,8 @@ Rec: !record
 func TestRecordComputedFieldNameInvalid(t *testing.T) {
 	src := `
 Rec: !record
+  fields:
+    unused: int
   computedFields:
     A: 1
 `

--- a/tooling/pkg/dsl/validation_topological_sort_test.go
+++ b/tooling/pkg/dsl/validation_topological_sort_test.go
@@ -41,6 +41,8 @@ R1: !record
   fields:
     f1: R2<R1>
 R2<T>: !record
+  fields:
+    f1: T
 `
 	_, err := parseAndValidate(t, src)
 	require.ErrorContains(t, err, "there is a reference cycle, which is not supported, within namespace 'test': Record 'R1' -> Field 'f1' -> Record 'R1'")

--- a/tooling/pkg/dsl/validation_type_resolution_test.go
+++ b/tooling/pkg/dsl/validation_type_resolution_test.go
@@ -12,6 +12,8 @@ import (
 func TestTypeNamesNotUnique(t *testing.T) {
 	src := `
 X: !record
+  fields:
+    unused: int
 X: !enum
 `
 	_, err := parseAndValidate(t, src)
@@ -21,7 +23,11 @@ X: !enum
 func TestTypeNamesNotUniqueOneWithGenericParameters(t *testing.T) {
 	src := `
 X<T>: !record
+  fields:
+    unused: T
 X<T1, T2>: !record
+  fields:
+    unused: [T1, T2]
 `
 	_, err := parseAndValidate(t, src)
 	assert.ErrorContains(t, err, "the name 'X' is already defined in ")

--- a/tooling/pkg/dsl/validation_unions_test.go
+++ b/tooling/pkg/dsl/validation_unions_test.go
@@ -65,7 +65,10 @@ X: !record
     f: !union
       g1: GenericRecord<int>
       g2: GenericRecord<int>
-GenericRecord<T>: !record`
+GenericRecord<T>: !record
+  fields:
+    unused: T
+`
 
 	_, err := parseAndValidate(t, src)
 	assert.ErrorContains(t, err, "redundant union type cases")

--- a/tooling/pkg/dsl/yaml_test.go
+++ b/tooling/pkg/dsl/yaml_test.go
@@ -67,6 +67,31 @@ func TestBasicErrors(t *testing.T) {
 	}
 }
 
+func TestEmptyFieldErrors(t *testing.T) {
+	testCases := []struct {
+		src string
+		err string
+	}{
+		{"P: !protocol", "must define a non-empty sequence"},
+		{"P: !protocol\n  sequence:", "must define a non-empty sequence"},
+		{"R: !record", "must define at least one field"},
+		{"R: !record\n  fields:", "must define at least one field"},
+		{`
+R: !record
+  fields:
+    x: int
+  computedFields:`, "computedFields cannot be empty"},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.src, func(t *testing.T) {
+			_, err := parse(t, tC.src)
+			require.ErrorContains(t, err, tC.err)
+		})
+	}
+
+}
+
 func TestCommentsOnRecords(t *testing.T) {
 	src := `
 # This is a comment on a record


### PR DESCRIPTION
Protocol specifications with zero steps and Record specifications with zero fields both produce invalid C++ code.

I fixed by making both required:
1. Protocols must include the `sequence` tag and at least one step
2. Records must include the `field` tag and at least one field
3. If a Record has a `computedFields` tag, it must also include at least one computed field

Closes #136 