### PR TITLE
Change MATLAB license file mounting

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -168,7 +168,8 @@ RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm \
     || (echo "MPM Installation Failure. See below for more information:" && cat /tmp/mathworks_root.log && false) \
     && sudo rm -f mpm /tmp/mathworks_root.log \
     && sudo ln -s ${MATLAB_INSTALL_LOCATION}/bin/matlab /usr/local/bin/matlab \
-    && sudo ln -s ${MATLAB_INSTALL_LOCATION} /opt/matlab/latest
+    && sudo ln -s ${MATLAB_INSTALL_LOCATION} /opt/matlab/latest \
+    && sudo mkdir -p ${MATLAB_INSTALL_LOCATION}/licenses
 
 # Install workaround run-matlab-command script to unify local and CI invocations of `matlab -batch`
 # See https://github.com/matlab-actions/run-command/issues/53

--- a/.devcontainer/devcontainer-on-create.sh
+++ b/.devcontainer/devcontainer-on-create.sh
@@ -7,5 +7,5 @@ host_license_file="/tmp/matlab.host.lic"
 if [ -s "${host_license_file}" ]; then
     # We don't bind mount directly to $MATLAB_LICENSE_FILE so that we can write
     # to it later without affecting the host.
-    cp "${host_license_file}" "${MATLAB_LICENSE_FILE}"
+    sudo cp "${host_license_file}" "${MATLAB_LICENSE_FILE}"
 fi

--- a/.devcontainer/devcontainer-on-create.sh
+++ b/.devcontainer/devcontainer-on-create.sh
@@ -1,5 +1,11 @@
 #! /usr/bin/env bash
 
-if [ -s /opt/matlab/latest/licenses/license.host.lic ]; then
-    cp /opt/matlab/latest/licenses/license.host.lic /opt/matlab/latest/licenses/license.lic
+set -euo pipefail
+
+host_license_file="/tmp/matlab.host.lic"
+
+if [ -s "${host_license_file}" ]; then
+    # We don't bind mount directly to $MATLAB_LICENSE_FILE so that we can write
+    # to it later without affecting the host.
+    cp "${host_license_file}" "${MATLAB_LICENSE_FILE}"
 fi

--- a/.devcontainer/devcontainer-on-create.sh
+++ b/.devcontainer/devcontainer-on-create.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+if [ -s /opt/matlab/latest/licenses/license.host.lic ]; then
+    cp /opt/matlab/latest/licenses/license.host.lic /opt/matlab/latest/licenses/license.lic
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,13 +6,19 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--network=host"
+  ],
   "overrideCommand": false,
   "mounts": [
     // Bind mount docker socket under an alias to support docker-from-docker
     "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind",
-    "source=${localEnv:MATLAB_LICENSE_FILE:/dev/null},target=/opt/matlab/latest/licenses/license.lic,type=bind"
+    "source=${localEnv:MATLAB_LICENSE_FILE:/dev/null},target=/opt/matlab/latest/licenses/license.host.lic,type=bind,readonly"
   ],
+  "onCreateCommand": ".devcontainer/devcontainer-on-create.sh",
   "remoteUser": "vscode",
 
   // Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
   "mounts": [
     // Bind mount docker socket under an alias to support docker-from-docker
     "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind",
-    "source=${localEnv:MATLAB_LICENSE_FILE:/dev/null},target=/opt/matlab/latest/licenses/license.host.lic,type=bind,readonly"
+    "source=${localEnv:MATLAB_LICENSE_FILE:/dev/null},target=/tmp/matlab.host.lic,type=bind,readonly"
   ],
   "onCreateCommand": ".devcontainer/devcontainer-on-create.sh",
   "remoteUser": "vscode",
@@ -126,6 +126,7 @@
 
   "containerEnv": {
     "PYTHONPATH": "/workspaces/yardl/python",
-    "CGO_ENABLED": "0"
+    "CGO_ENABLED": "0",
+    "MATLAB_LICENSE_FILE": "/opt/matlab/latest/licenses/license.lic"
   }
 }


### PR DESCRIPTION
Proposing small changes to the way we make a MATLAB license available to the devcontainer. Instead of bind mounting the file directly, we bind mount to a temporary location so that the license file can be updated in the devcontainer without affecting the host.