### PR TITLE
Add option to partially consume a binary protocol

### DIFF
--- a/cpp/evolution/v0/generated/binary/protocols.cc
+++ b/cpp/evolution/v0/generated/binary/protocols.cc
@@ -1546,7 +1546,9 @@ bool ProtocolWithChangesReader::ReadStreamedRecordWithChangesImpl(std::vector<ev
 }
 
 void ProtocolWithChangesReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void UnusedProtocolWriter::WriteRecordsImpl(evo_test::UnchangedRecord const& value) {
@@ -1583,7 +1585,9 @@ bool UnusedProtocolReader::ReadRecordsImpl(std::vector<evo_test::UnchangedRecord
 }
 
 void UnusedProtocolReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 } // namespace evo_test::binary

--- a/cpp/evolution/v0/generated/binary/protocols.h
+++ b/cpp/evolution/v0/generated/binary/protocols.h
@@ -146,11 +146,11 @@ class ProtocolWithChangesWriter : public evo_test::ProtocolWithChangesWriterBase
 // Binary reader for the ProtocolWithChanges protocol.
 class ProtocolWithChangesReader : public evo_test::ProtocolWithChangesReaderBase, yardl::binary::BinaryReader {
   public:
-  ProtocolWithChangesReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithChangesReader(std::istream& stream, bool skip_completed_check=false)
+      : evo_test::ProtocolWithChangesReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ProtocolWithChangesReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithChangesReader(std::string file_name, bool skip_completed_check=false)
+      : evo_test::ProtocolWithChangesReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -292,11 +292,11 @@ class UnusedProtocolWriter : public evo_test::UnusedProtocolWriterBase, yardl::b
 // Binary reader for the UnusedProtocol protocol.
 class UnusedProtocolReader : public evo_test::UnusedProtocolReaderBase, yardl::binary::BinaryReader {
   public:
-  UnusedProtocolReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(evo_test::UnusedProtocolReaderBase::VersionFromSchema(schema_read_)) {}
+  UnusedProtocolReader(std::istream& stream, bool skip_completed_check=false)
+      : evo_test::UnusedProtocolReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(evo_test::UnusedProtocolReaderBase::VersionFromSchema(schema_read_)) {}
 
-  UnusedProtocolReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(evo_test::UnusedProtocolReaderBase::VersionFromSchema(schema_read_)) {}
+  UnusedProtocolReader(std::string file_name, bool skip_completed_check=false)
+      : evo_test::UnusedProtocolReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(evo_test::UnusedProtocolReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 

--- a/cpp/evolution/v0/generated/protocols.cc
+++ b/cpp/evolution/v0/generated/protocols.cc
@@ -2600,7 +2600,7 @@ bool ProtocolWithChangesReaderBase::ReadStreamedRecordWithChangesImpl(std::vecto
 }
 
 void ProtocolWithChangesReaderBase::Close() {
-  if (unlikely(state_ != 200)) {
+  if (!skip_completed_check_ && unlikely(state_ != 200)) {
     if (state_ == 199) {
       state_ = 200;
     } else {
@@ -3311,7 +3311,7 @@ bool UnusedProtocolReaderBase::ReadRecordsImpl(std::vector<evo_test::UnchangedRe
 }
 
 void UnusedProtocolReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     if (state_ == 1) {
       state_ = 2;
     } else {

--- a/cpp/evolution/v0/generated/protocols.h
+++ b/cpp/evolution/v0/generated/protocols.h
@@ -499,6 +499,8 @@ class ProtocolWithChangesWriterBase {
 // Abstract reader for the ProtocolWithChanges protocol.
 class ProtocolWithChangesReaderBase {
   public:
+  ProtocolWithChangesReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadInt8ToInt(int8_t& value);
 
@@ -941,6 +943,8 @@ class ProtocolWithChangesReaderBase {
 
   static Version VersionFromSchema(const std::string& schema);
 
+  bool skip_completed_check_;
+
   private:
   uint8_t state_ = 0;
 };
@@ -988,6 +992,8 @@ class UnusedProtocolWriterBase {
 // Abstract reader for the UnusedProtocol protocol.
 class UnusedProtocolReaderBase {
   public:
+  UnusedProtocolReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadRecords(evo_test::UnchangedRecord& value);
 
@@ -1010,6 +1016,8 @@ class UnusedProtocolReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;

--- a/cpp/evolution/v1/generated/binary/protocols.cc
+++ b/cpp/evolution/v1/generated/binary/protocols.cc
@@ -4870,7 +4870,9 @@ bool ProtocolWithChangesReader::ReadAddedRecordStreamImpl(std::vector<evo_test::
 }
 
 void ProtocolWithChangesReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void UnusedProtocolWriter::WriteRecordsImpl(evo_test::UnchangedRecord const& value) {
@@ -4907,7 +4909,9 @@ bool UnusedProtocolReader::ReadRecordsImpl(std::vector<evo_test::UnchangedRecord
 }
 
 void UnusedProtocolReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 } // namespace evo_test::binary

--- a/cpp/evolution/v1/generated/binary/protocols.h
+++ b/cpp/evolution/v1/generated/binary/protocols.h
@@ -157,11 +157,11 @@ class ProtocolWithChangesWriter : public evo_test::ProtocolWithChangesWriterBase
 // Binary reader for the ProtocolWithChanges protocol.
 class ProtocolWithChangesReader : public evo_test::ProtocolWithChangesReaderBase, yardl::binary::BinaryReader {
   public:
-  ProtocolWithChangesReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithChangesReader(std::istream& stream, bool skip_completed_check=false)
+      : evo_test::ProtocolWithChangesReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ProtocolWithChangesReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithChangesReader(std::string file_name, bool skip_completed_check=false)
+      : evo_test::ProtocolWithChangesReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -311,11 +311,11 @@ class UnusedProtocolWriter : public evo_test::UnusedProtocolWriterBase, yardl::b
 // Binary reader for the UnusedProtocol protocol.
 class UnusedProtocolReader : public evo_test::UnusedProtocolReaderBase, yardl::binary::BinaryReader {
   public:
-  UnusedProtocolReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(evo_test::UnusedProtocolReaderBase::VersionFromSchema(schema_read_)) {}
+  UnusedProtocolReader(std::istream& stream, bool skip_completed_check=false)
+      : evo_test::UnusedProtocolReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(evo_test::UnusedProtocolReaderBase::VersionFromSchema(schema_read_)) {}
 
-  UnusedProtocolReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(evo_test::UnusedProtocolReaderBase::VersionFromSchema(schema_read_)) {}
+  UnusedProtocolReader(std::string file_name, bool skip_completed_check=false)
+      : evo_test::UnusedProtocolReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(evo_test::UnusedProtocolReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 

--- a/cpp/evolution/v1/generated/protocols.cc
+++ b/cpp/evolution/v1/generated/protocols.cc
@@ -2934,7 +2934,7 @@ bool ProtocolWithChangesReaderBase::ReadAddedRecordStreamImpl(std::vector<evo_te
 }
 
 void ProtocolWithChangesReaderBase::Close() {
-  if (unlikely(state_ != 210)) {
+  if (!skip_completed_check_ && unlikely(state_ != 210)) {
     if (state_ == 209) {
       state_ = 210;
     } else {
@@ -3702,7 +3702,7 @@ bool UnusedProtocolReaderBase::ReadRecordsImpl(std::vector<evo_test::UnchangedRe
 }
 
 void UnusedProtocolReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     if (state_ == 1) {
       state_ = 2;
     } else {

--- a/cpp/evolution/v1/generated/protocols.h
+++ b/cpp/evolution/v1/generated/protocols.h
@@ -550,6 +550,8 @@ class ProtocolWithChangesWriterBase {
 // Abstract reader for the ProtocolWithChanges protocol.
 class ProtocolWithChangesReaderBase {
   public:
+  ProtocolWithChangesReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadInt8ToInt(int32_t& value);
 
@@ -1024,6 +1026,8 @@ class ProtocolWithChangesReaderBase {
 
   static Version VersionFromSchema(const std::string& schema);
 
+  bool skip_completed_check_;
+
   private:
   uint8_t state_ = 0;
 };
@@ -1071,6 +1075,8 @@ class UnusedProtocolWriterBase {
 // Abstract reader for the UnusedProtocol protocol.
 class UnusedProtocolReaderBase {
   public:
+  UnusedProtocolReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadRecords(evo_test::UnchangedRecord& value);
 
@@ -1093,6 +1099,8 @@ class UnusedProtocolReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;

--- a/cpp/evolution/v2/generated/binary/protocols.cc
+++ b/cpp/evolution/v2/generated/binary/protocols.cc
@@ -5382,7 +5382,9 @@ bool ProtocolWithChangesReader::ReadAddedUnionStreamImpl(std::vector<std::varian
 }
 
 void ProtocolWithChangesReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 } // namespace evo_test::binary

--- a/cpp/evolution/v2/generated/binary/protocols.h
+++ b/cpp/evolution/v2/generated/binary/protocols.h
@@ -162,11 +162,11 @@ class ProtocolWithChangesWriter : public evo_test::ProtocolWithChangesWriterBase
 // Binary reader for the ProtocolWithChanges protocol.
 class ProtocolWithChangesReader : public evo_test::ProtocolWithChangesReaderBase, yardl::binary::BinaryReader {
   public:
-  ProtocolWithChangesReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithChangesReader(std::istream& stream, bool skip_completed_check=false)
+      : evo_test::ProtocolWithChangesReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ProtocolWithChangesReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithChangesReader(std::string file_name, bool skip_completed_check=false)
+      : evo_test::ProtocolWithChangesReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(evo_test::ProtocolWithChangesReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 

--- a/cpp/evolution/v2/generated/protocols.cc
+++ b/cpp/evolution/v2/generated/protocols.cc
@@ -3078,7 +3078,7 @@ bool ProtocolWithChangesReaderBase::ReadAddedUnionStreamImpl(std::vector<std::va
 }
 
 void ProtocolWithChangesReaderBase::Close() {
-  if (unlikely(state_ != 216)) {
+  if (!skip_completed_check_ && unlikely(state_ != 216)) {
     if (state_ == 215) {
       state_ = 216;
     } else {

--- a/cpp/evolution/v2/generated/protocols.h
+++ b/cpp/evolution/v2/generated/protocols.h
@@ -573,6 +573,8 @@ class ProtocolWithChangesWriterBase {
 // Abstract reader for the ProtocolWithChanges protocol.
 class ProtocolWithChangesReaderBase {
   public:
+  ProtocolWithChangesReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadInt8ToInt(int8_t& value);
 
@@ -1062,6 +1064,8 @@ class ProtocolWithChangesReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(tests
   binary/coded_stream_test.cc
   binary/header_test.cc
+  binary/partial_read_test.cc
   computed_fields_test.cc
   definitions_test.cc
   hdf5/hdf5_test.cc

--- a/cpp/test/binary/partial_read_test.cc
+++ b/cpp/test/binary/partial_read_test.cc
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <iostream>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include "../generated/binary/protocols.h"
+#include "../generated/yardl/detail/binary/header.h"
+#include "../generated/yardl/detail/binary/serializers.h"
+
+using namespace yardl::binary;
+using namespace test_model;
+using namespace test_model::binary;
+
+namespace {
+
+std::stringstream GenerateStream() {
+  std::stringstream ss;
+  {
+    StateTestWriter w(ss);
+    w.WriteAnInt(42);
+    std::vector<int> stream{1, 2, 3, 4, 5};
+    w.WriteAStream(stream);
+    w.EndAStream();
+    w.WriteAnotherInt(153);
+  }
+  ss.seekg(0);
+  return ss;
+}
+
+TEST(PartialReadTests, SkipSteps) {
+  {
+    std::stringstream ss = GenerateStream();
+    StateTestReader r(ss, true);
+    int value;
+    r.ReadAnInt(value);
+
+    ASSERT_NO_THROW(r.Close());
+  }
+
+  {
+    std::stringstream ss = GenerateStream();
+    StateTestReader r(ss, true);
+    int value;
+    r.ReadAnInt(value);
+    while (r.ReadAStream(value)) {
+      // pass
+    }
+
+    ASSERT_NO_THROW(r.Close());
+  }
+}
+
+TEST(PartialReadTests, SkipStreamItems) {
+  std::stringstream ss = GenerateStream();
+  {
+    StateTestReader r(ss, true);
+    int value;
+    r.ReadAnInt(value);
+    GTEST_ASSERT_TRUE(r.ReadAStream(value));
+    GTEST_ASSERT_TRUE(r.ReadAStream(value));
+
+    ASSERT_NO_THROW(r.Close());
+  }
+}
+
+}  // namespace

--- a/cpp/test/generated/binary/protocols.cc
+++ b/cpp/test/generated/binary/protocols.cc
@@ -2957,7 +2957,9 @@ bool BenchmarkFloat256x256Reader::ReadFloat256x256Impl(std::vector<yardl::FixedN
 }
 
 void BenchmarkFloat256x256Reader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void BenchmarkInt256x256Writer::WriteInt256x256Impl(yardl::FixedNDArray<int32_t, 256, 256> const& value) {
@@ -2994,7 +2996,9 @@ bool BenchmarkInt256x256Reader::ReadInt256x256Impl(std::vector<yardl::FixedNDArr
 }
 
 void BenchmarkInt256x256Reader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void BenchmarkFloatVlenWriter::WriteFloatArrayImpl(yardl::NDArray<float, 2> const& value) {
@@ -3031,7 +3035,9 @@ bool BenchmarkFloatVlenReader::ReadFloatArrayImpl(std::vector<yardl::NDArray<flo
 }
 
 void BenchmarkFloatVlenReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void BenchmarkSmallRecordWriter::WriteSmallRecordImpl(test_model::SmallBenchmarkRecord const& value) {
@@ -3068,7 +3074,9 @@ bool BenchmarkSmallRecordReader::ReadSmallRecordImpl(std::vector<test_model::Sma
 }
 
 void BenchmarkSmallRecordReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void BenchmarkSmallRecordWithOptionalsWriter::WriteSmallRecordImpl(test_model::SimpleEncodingCounters const& value) {
@@ -3105,7 +3113,9 @@ bool BenchmarkSmallRecordWithOptionalsReader::ReadSmallRecordImpl(std::vector<te
 }
 
 void BenchmarkSmallRecordWithOptionalsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void BenchmarkSimpleMrdWriter::WriteDataImpl(std::variant<test_model::SimpleAcquisition, image::Image<float>> const& value) {
@@ -3142,7 +3152,9 @@ bool BenchmarkSimpleMrdReader::ReadDataImpl(std::vector<std::variant<test_model:
 }
 
 void BenchmarkSimpleMrdReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void ScalarsWriter::WriteInt32Impl(int32_t const& value) {
@@ -3170,7 +3182,9 @@ void ScalarsReader::ReadRecordImpl(test_model::RecordWithPrimitives& value) {
 }
 
 void ScalarsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void ScalarOptionalsWriter::WriteOptionalIntImpl(std::optional<int32_t> const& value) {
@@ -3214,7 +3228,9 @@ void ScalarOptionalsReader::ReadOptionalRecordWithOptionalFieldsImpl(std::option
 }
 
 void ScalarOptionalsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void NestedRecordsWriter::WriteTupleWithRecordsImpl(test_model::TupleWithRecords const& value) {
@@ -3234,7 +3250,9 @@ void NestedRecordsReader::ReadTupleWithRecordsImpl(test_model::TupleWithRecords&
 }
 
 void NestedRecordsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void VlensWriter::WriteIntVectorImpl(std::vector<int32_t> const& value) {
@@ -3278,7 +3296,9 @@ void VlensReader::ReadVlenOfRecordWithVlensImpl(std::vector<test_model::RecordWi
 }
 
 void VlensReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void StringsWriter::WriteSingleStringImpl(std::string const& value) {
@@ -3306,7 +3326,9 @@ void StringsReader::ReadRecWithStringImpl(test_model::RecordWithStrings& value) 
 }
 
 void StringsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void OptionalVectorsWriter::WriteRecordWithOptionalVectorImpl(test_model::RecordWithOptionalVector const& value) {
@@ -3326,7 +3348,9 @@ void OptionalVectorsReader::ReadRecordWithOptionalVectorImpl(test_model::RecordW
 }
 
 void OptionalVectorsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void FixedVectorsWriter::WriteFixedIntVectorImpl(std::array<int32_t, 5> const& value) {
@@ -3370,7 +3394,9 @@ void FixedVectorsReader::ReadRecordWithFixedVectorsImpl(test_model::RecordWithFi
 }
 
 void FixedVectorsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void StreamsWriter::WriteIntDataImpl(int32_t const& value) {
@@ -3482,7 +3508,9 @@ bool StreamsReader::ReadFixedVectorImpl(std::vector<std::array<int32_t, 3>>& val
 }
 
 void StreamsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void FixedArraysWriter::WriteIntsImpl(yardl::FixedNDArray<int32_t, 2, 3> const& value) {
@@ -3534,7 +3562,9 @@ void FixedArraysReader::ReadNamedArrayImpl(test_model::NamedFixedNDArray& value)
 }
 
 void FixedArraysReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void SubarraysWriter::WriteDynamicWithFixedIntSubarrayImpl(yardl::DynamicNDArray<yardl::FixedNDArray<int32_t, 3>> const& value) {
@@ -3618,7 +3648,9 @@ void SubarraysReader::ReadGenericSubarrayImpl(test_model::Image<yardl::FixedNDAr
 }
 
 void SubarraysReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void SubarraysInRecordsWriter::WriteWithFixedSubarraysImpl(yardl::DynamicNDArray<test_model::RecordWithFixedCollections> const& value) {
@@ -3646,7 +3678,9 @@ void SubarraysInRecordsReader::ReadWithVlenSubarraysImpl(yardl::DynamicNDArray<t
 }
 
 void SubarraysInRecordsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void NDArraysWriter::WriteIntsImpl(yardl::NDArray<int32_t, 2> const& value) {
@@ -3698,7 +3732,9 @@ void NDArraysReader::ReadNamedArrayImpl(test_model::NamedNDArray& value) {
 }
 
 void NDArraysReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void NDArraysSingleDimensionWriter::WriteIntsImpl(yardl::NDArray<int32_t, 1> const& value) {
@@ -3742,7 +3778,9 @@ void NDArraysSingleDimensionReader::ReadRecordWithNDArraysImpl(test_model::Recor
 }
 
 void NDArraysSingleDimensionReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void DynamicNDArraysWriter::WriteIntsImpl(yardl::DynamicNDArray<int32_t> const& value) {
@@ -3786,7 +3824,9 @@ void DynamicNDArraysReader::ReadRecordWithDynamicNDArraysImpl(test_model::Record
 }
 
 void DynamicNDArraysReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void MultiDArraysWriter::WriteImagesImpl(yardl::NDArray<float, 4> const& value) {
@@ -3848,7 +3888,9 @@ bool MultiDArraysReader::ReadFramesImpl(std::vector<yardl::FixedNDArray<float, 1
 }
 
 void MultiDArraysReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void ComplexArraysWriter::WriteFloatsImpl(yardl::DynamicNDArray<std::complex<float>> const& value) {
@@ -3876,7 +3918,9 @@ void ComplexArraysReader::ReadDoublesImpl(yardl::NDArray<std::complex<double>, 2
 }
 
 void ComplexArraysReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void MapsWriter::WriteStringToIntImpl(std::unordered_map<std::string, int32_t> const& value) {
@@ -3928,7 +3972,9 @@ void MapsReader::ReadRecordsImpl(std::vector<test_model::RecordWithMaps>& value)
 }
 
 void MapsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void UnionsWriter::WriteIntOrSimpleRecordImpl(std::variant<int32_t, test_model::SimpleRecord> const& value) {
@@ -3972,7 +4018,9 @@ void UnionsReader::ReadRecordWithUnionsImpl(basic_types::RecordWithUnions& value
 }
 
 void UnionsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void StreamsOfUnionsWriter::WriteIntOrSimpleRecordImpl(std::variant<int32_t, test_model::SimpleRecord> const& value) {
@@ -4059,7 +4107,9 @@ bool StreamsOfUnionsReader::ReadManyCasesImpl(std::vector<std::variant<int32_t, 
 }
 
 void StreamsOfUnionsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void EnumsWriter::WriteSingleImpl(test_model::Fruits const& value) {
@@ -4103,7 +4153,9 @@ void EnumsReader::ReadRecImpl(test_model::RecordWithEnums& value) {
 }
 
 void EnumsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void FlagsWriter::WriteDaysImpl(test_model::DaysOfWeek const& value) {
@@ -4165,7 +4217,9 @@ bool FlagsReader::ReadFormatsImpl(std::vector<test_model::TextFormat>& values) {
 }
 
 void FlagsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void StateTestWriter::WriteAnIntImpl(int32_t const& value) {
@@ -4218,7 +4272,9 @@ void StateTestReader::ReadAnotherIntImpl(int32_t& value) {
 }
 
 void StateTestReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void SimpleGenericsWriter::WriteFloatImageImpl(image::FloatImage const& value) {
@@ -4319,7 +4375,9 @@ bool SimpleGenericsReader::ReadStreamOfTypeVariantsImpl(std::vector<std::variant
 }
 
 void SimpleGenericsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void AdvancedGenericsWriter::WriteFloatImageImageImpl(test_model::Image<test_model::Image<float>> const& value) {
@@ -4371,7 +4429,9 @@ void AdvancedGenericsReader::ReadTupleOfVectorsImpl(test_model::MyTuple<std::vec
 }
 
 void AdvancedGenericsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void AliasesWriter::WriteAliasedStringImpl(test_model::AliasedString const& value) {
@@ -4488,7 +4548,9 @@ void AliasesReader::ReadVectorsImpl(std::vector<test_model::RecordContainingVect
 }
 
 void AliasesReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void StreamsOfAliasedUnionsWriter::WriteIntOrSimpleRecordImpl(test_model::AliasedIntOrSimpleRecord const& value) {
@@ -4550,7 +4612,9 @@ bool StreamsOfAliasedUnionsReader::ReadNullableIntOrSimpleRecordImpl(std::vector
 }
 
 void StreamsOfAliasedUnionsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void ProtocolWithComputedFieldsWriter::WriteRecordWithComputedFieldsImpl(test_model::RecordWithComputedFields const& value) {
@@ -4570,7 +4634,9 @@ void ProtocolWithComputedFieldsReader::ReadRecordWithComputedFieldsImpl(test_mod
 }
 
 void ProtocolWithComputedFieldsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void ProtocolWithKeywordStepsWriter::WriteIntImpl(test_model::RecordWithKeywordFields const& value) {
@@ -4615,7 +4681,9 @@ void ProtocolWithKeywordStepsReader::ReadFloatImpl(test_model::EnumWithKeywordSy
 }
 
 void ProtocolWithKeywordStepsReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 void ProtocolWithOptionalDateWriter::WriteRecordImpl(std::optional<test_model::RecordWithOptionalDate> const& value) {
@@ -4635,7 +4703,9 @@ void ProtocolWithOptionalDateReader::ReadRecordImpl(std::optional<test_model::Re
 }
 
 void ProtocolWithOptionalDateReader::CloseImpl() {
-  stream_.VerifyFinished();
+  if (!skip_completed_check_) {
+    stream_.VerifyFinished();
+  }
 }
 
 } // namespace test_model::binary

--- a/cpp/test/generated/binary/protocols.h
+++ b/cpp/test/generated/binary/protocols.h
@@ -35,11 +35,11 @@ class BenchmarkFloat256x256Writer : public test_model::BenchmarkFloat256x256Writ
 // Binary reader for the BenchmarkFloat256x256 protocol.
 class BenchmarkFloat256x256Reader : public test_model::BenchmarkFloat256x256ReaderBase, yardl::binary::BinaryReader {
   public:
-  BenchmarkFloat256x256Reader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkFloat256x256ReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkFloat256x256Reader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::BenchmarkFloat256x256ReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkFloat256x256ReaderBase::VersionFromSchema(schema_read_)) {}
 
-  BenchmarkFloat256x256Reader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkFloat256x256ReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkFloat256x256Reader(std::string file_name, bool skip_completed_check=false)
+      : test_model::BenchmarkFloat256x256ReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkFloat256x256ReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -77,11 +77,11 @@ class BenchmarkInt256x256Writer : public test_model::BenchmarkInt256x256WriterBa
 // Binary reader for the BenchmarkInt256x256 protocol.
 class BenchmarkInt256x256Reader : public test_model::BenchmarkInt256x256ReaderBase, yardl::binary::BinaryReader {
   public:
-  BenchmarkInt256x256Reader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkInt256x256ReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkInt256x256Reader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::BenchmarkInt256x256ReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkInt256x256ReaderBase::VersionFromSchema(schema_read_)) {}
 
-  BenchmarkInt256x256Reader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkInt256x256ReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkInt256x256Reader(std::string file_name, bool skip_completed_check=false)
+      : test_model::BenchmarkInt256x256ReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkInt256x256ReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -119,11 +119,11 @@ class BenchmarkFloatVlenWriter : public test_model::BenchmarkFloatVlenWriterBase
 // Binary reader for the BenchmarkFloatVlen protocol.
 class BenchmarkFloatVlenReader : public test_model::BenchmarkFloatVlenReaderBase, yardl::binary::BinaryReader {
   public:
-  BenchmarkFloatVlenReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkFloatVlenReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkFloatVlenReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::BenchmarkFloatVlenReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkFloatVlenReaderBase::VersionFromSchema(schema_read_)) {}
 
-  BenchmarkFloatVlenReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkFloatVlenReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkFloatVlenReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::BenchmarkFloatVlenReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkFloatVlenReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -161,11 +161,11 @@ class BenchmarkSmallRecordWriter : public test_model::BenchmarkSmallRecordWriter
 // Binary reader for the BenchmarkSmallRecord protocol.
 class BenchmarkSmallRecordReader : public test_model::BenchmarkSmallRecordReaderBase, yardl::binary::BinaryReader {
   public:
-  BenchmarkSmallRecordReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkSmallRecordReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkSmallRecordReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::BenchmarkSmallRecordReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkSmallRecordReaderBase::VersionFromSchema(schema_read_)) {}
 
-  BenchmarkSmallRecordReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkSmallRecordReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkSmallRecordReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::BenchmarkSmallRecordReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkSmallRecordReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -203,11 +203,11 @@ class BenchmarkSmallRecordWithOptionalsWriter : public test_model::BenchmarkSmal
 // Binary reader for the BenchmarkSmallRecordWithOptionals protocol.
 class BenchmarkSmallRecordWithOptionalsReader : public test_model::BenchmarkSmallRecordWithOptionalsReaderBase, yardl::binary::BinaryReader {
   public:
-  BenchmarkSmallRecordWithOptionalsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkSmallRecordWithOptionalsReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkSmallRecordWithOptionalsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::BenchmarkSmallRecordWithOptionalsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkSmallRecordWithOptionalsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  BenchmarkSmallRecordWithOptionalsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkSmallRecordWithOptionalsReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkSmallRecordWithOptionalsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::BenchmarkSmallRecordWithOptionalsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkSmallRecordWithOptionalsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -245,11 +245,11 @@ class BenchmarkSimpleMrdWriter : public test_model::BenchmarkSimpleMrdWriterBase
 // Binary reader for the BenchmarkSimpleMrd protocol.
 class BenchmarkSimpleMrdReader : public test_model::BenchmarkSimpleMrdReaderBase, yardl::binary::BinaryReader {
   public:
-  BenchmarkSimpleMrdReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkSimpleMrdReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkSimpleMrdReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::BenchmarkSimpleMrdReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::BenchmarkSimpleMrdReaderBase::VersionFromSchema(schema_read_)) {}
 
-  BenchmarkSimpleMrdReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkSimpleMrdReaderBase::VersionFromSchema(schema_read_)) {}
+  BenchmarkSimpleMrdReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::BenchmarkSimpleMrdReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::BenchmarkSimpleMrdReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -286,11 +286,11 @@ class ScalarsWriter : public test_model::ScalarsWriterBase, yardl::binary::Binar
 // Binary reader for the Scalars protocol.
 class ScalarsReader : public test_model::ScalarsReaderBase, yardl::binary::BinaryReader {
   public:
-  ScalarsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::ScalarsReaderBase::VersionFromSchema(schema_read_)) {}
+  ScalarsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::ScalarsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::ScalarsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ScalarsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::ScalarsReaderBase::VersionFromSchema(schema_read_)) {}
+  ScalarsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::ScalarsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::ScalarsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -326,11 +326,11 @@ class ScalarOptionalsWriter : public test_model::ScalarOptionalsWriterBase, yard
 // Binary reader for the ScalarOptionals protocol.
 class ScalarOptionalsReader : public test_model::ScalarOptionalsReaderBase, yardl::binary::BinaryReader {
   public:
-  ScalarOptionalsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::ScalarOptionalsReaderBase::VersionFromSchema(schema_read_)) {}
+  ScalarOptionalsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::ScalarOptionalsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::ScalarOptionalsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ScalarOptionalsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::ScalarOptionalsReaderBase::VersionFromSchema(schema_read_)) {}
+  ScalarOptionalsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::ScalarOptionalsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::ScalarOptionalsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -365,11 +365,11 @@ class NestedRecordsWriter : public test_model::NestedRecordsWriterBase, yardl::b
 // Binary reader for the NestedRecords protocol.
 class NestedRecordsReader : public test_model::NestedRecordsReaderBase, yardl::binary::BinaryReader {
   public:
-  NestedRecordsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::NestedRecordsReaderBase::VersionFromSchema(schema_read_)) {}
+  NestedRecordsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::NestedRecordsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::NestedRecordsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  NestedRecordsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::NestedRecordsReaderBase::VersionFromSchema(schema_read_)) {}
+  NestedRecordsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::NestedRecordsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::NestedRecordsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -404,11 +404,11 @@ class VlensWriter : public test_model::VlensWriterBase, yardl::binary::BinaryWri
 // Binary reader for the Vlens protocol.
 class VlensReader : public test_model::VlensReaderBase, yardl::binary::BinaryReader {
   public:
-  VlensReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::VlensReaderBase::VersionFromSchema(schema_read_)) {}
+  VlensReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::VlensReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::VlensReaderBase::VersionFromSchema(schema_read_)) {}
 
-  VlensReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::VlensReaderBase::VersionFromSchema(schema_read_)) {}
+  VlensReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::VlensReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::VlensReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -444,11 +444,11 @@ class StringsWriter : public test_model::StringsWriterBase, yardl::binary::Binar
 // Binary reader for the Strings protocol.
 class StringsReader : public test_model::StringsReaderBase, yardl::binary::BinaryReader {
   public:
-  StringsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::StringsReaderBase::VersionFromSchema(schema_read_)) {}
+  StringsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::StringsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::StringsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  StringsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::StringsReaderBase::VersionFromSchema(schema_read_)) {}
+  StringsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::StringsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::StringsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -481,11 +481,11 @@ class OptionalVectorsWriter : public test_model::OptionalVectorsWriterBase, yard
 // Binary reader for the OptionalVectors protocol.
 class OptionalVectorsReader : public test_model::OptionalVectorsReaderBase, yardl::binary::BinaryReader {
   public:
-  OptionalVectorsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::OptionalVectorsReaderBase::VersionFromSchema(schema_read_)) {}
+  OptionalVectorsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::OptionalVectorsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::OptionalVectorsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  OptionalVectorsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::OptionalVectorsReaderBase::VersionFromSchema(schema_read_)) {}
+  OptionalVectorsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::OptionalVectorsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::OptionalVectorsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -520,11 +520,11 @@ class FixedVectorsWriter : public test_model::FixedVectorsWriterBase, yardl::bin
 // Binary reader for the FixedVectors protocol.
 class FixedVectorsReader : public test_model::FixedVectorsReaderBase, yardl::binary::BinaryReader {
   public:
-  FixedVectorsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::FixedVectorsReaderBase::VersionFromSchema(schema_read_)) {}
+  FixedVectorsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::FixedVectorsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::FixedVectorsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  FixedVectorsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::FixedVectorsReaderBase::VersionFromSchema(schema_read_)) {}
+  FixedVectorsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::FixedVectorsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::FixedVectorsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -570,11 +570,11 @@ class StreamsWriter : public test_model::StreamsWriterBase, yardl::binary::Binar
 // Binary reader for the Streams protocol.
 class StreamsReader : public test_model::StreamsReaderBase, yardl::binary::BinaryReader {
   public:
-  StreamsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::StreamsReaderBase::VersionFromSchema(schema_read_)) {}
+  StreamsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::StreamsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::StreamsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  StreamsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::StreamsReaderBase::VersionFromSchema(schema_read_)) {}
+  StreamsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::StreamsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::StreamsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -620,11 +620,11 @@ class FixedArraysWriter : public test_model::FixedArraysWriterBase, yardl::binar
 // Binary reader for the FixedArrays protocol.
 class FixedArraysReader : public test_model::FixedArraysReaderBase, yardl::binary::BinaryReader {
   public:
-  FixedArraysReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::FixedArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  FixedArraysReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::FixedArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::FixedArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
-  FixedArraysReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::FixedArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  FixedArraysReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::FixedArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::FixedArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -668,11 +668,11 @@ class SubarraysWriter : public test_model::SubarraysWriterBase, yardl::binary::B
 // Binary reader for the Subarrays protocol.
 class SubarraysReader : public test_model::SubarraysReaderBase, yardl::binary::BinaryReader {
   public:
-  SubarraysReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::SubarraysReaderBase::VersionFromSchema(schema_read_)) {}
+  SubarraysReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::SubarraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::SubarraysReaderBase::VersionFromSchema(schema_read_)) {}
 
-  SubarraysReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::SubarraysReaderBase::VersionFromSchema(schema_read_)) {}
+  SubarraysReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::SubarraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::SubarraysReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -713,11 +713,11 @@ class SubarraysInRecordsWriter : public test_model::SubarraysInRecordsWriterBase
 // Binary reader for the SubarraysInRecords protocol.
 class SubarraysInRecordsReader : public test_model::SubarraysInRecordsReaderBase, yardl::binary::BinaryReader {
   public:
-  SubarraysInRecordsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::SubarraysInRecordsReaderBase::VersionFromSchema(schema_read_)) {}
+  SubarraysInRecordsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::SubarraysInRecordsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::SubarraysInRecordsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  SubarraysInRecordsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::SubarraysInRecordsReaderBase::VersionFromSchema(schema_read_)) {}
+  SubarraysInRecordsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::SubarraysInRecordsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::SubarraysInRecordsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -754,11 +754,11 @@ class NDArraysWriter : public test_model::NDArraysWriterBase, yardl::binary::Bin
 // Binary reader for the NDArrays protocol.
 class NDArraysReader : public test_model::NDArraysReaderBase, yardl::binary::BinaryReader {
   public:
-  NDArraysReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::NDArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  NDArraysReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::NDArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::NDArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
-  NDArraysReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::NDArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  NDArraysReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::NDArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::NDArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -797,11 +797,11 @@ class NDArraysSingleDimensionWriter : public test_model::NDArraysSingleDimension
 // Binary reader for the NDArraysSingleDimension protocol.
 class NDArraysSingleDimensionReader : public test_model::NDArraysSingleDimensionReaderBase, yardl::binary::BinaryReader {
   public:
-  NDArraysSingleDimensionReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::NDArraysSingleDimensionReaderBase::VersionFromSchema(schema_read_)) {}
+  NDArraysSingleDimensionReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::NDArraysSingleDimensionReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::NDArraysSingleDimensionReaderBase::VersionFromSchema(schema_read_)) {}
 
-  NDArraysSingleDimensionReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::NDArraysSingleDimensionReaderBase::VersionFromSchema(schema_read_)) {}
+  NDArraysSingleDimensionReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::NDArraysSingleDimensionReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::NDArraysSingleDimensionReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -839,11 +839,11 @@ class DynamicNDArraysWriter : public test_model::DynamicNDArraysWriterBase, yard
 // Binary reader for the DynamicNDArrays protocol.
 class DynamicNDArraysReader : public test_model::DynamicNDArraysReaderBase, yardl::binary::BinaryReader {
   public:
-  DynamicNDArraysReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::DynamicNDArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  DynamicNDArraysReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::DynamicNDArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::DynamicNDArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
-  DynamicNDArraysReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::DynamicNDArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  DynamicNDArraysReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::DynamicNDArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::DynamicNDArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -883,11 +883,11 @@ class MultiDArraysWriter : public test_model::MultiDArraysWriterBase, yardl::bin
 // Binary reader for the MultiDArrays protocol.
 class MultiDArraysReader : public test_model::MultiDArraysReaderBase, yardl::binary::BinaryReader {
   public:
-  MultiDArraysReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::MultiDArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  MultiDArraysReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::MultiDArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::MultiDArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
-  MultiDArraysReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::MultiDArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  MultiDArraysReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::MultiDArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::MultiDArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -926,11 +926,11 @@ class ComplexArraysWriter : public test_model::ComplexArraysWriterBase, yardl::b
 // Binary reader for the ComplexArrays protocol.
 class ComplexArraysReader : public test_model::ComplexArraysReaderBase, yardl::binary::BinaryReader {
   public:
-  ComplexArraysReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::ComplexArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  ComplexArraysReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::ComplexArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::ComplexArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ComplexArraysReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::ComplexArraysReaderBase::VersionFromSchema(schema_read_)) {}
+  ComplexArraysReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::ComplexArraysReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::ComplexArraysReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -967,11 +967,11 @@ class MapsWriter : public test_model::MapsWriterBase, yardl::binary::BinaryWrite
 // Binary reader for the Maps protocol.
 class MapsReader : public test_model::MapsReaderBase, yardl::binary::BinaryReader {
   public:
-  MapsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::MapsReaderBase::VersionFromSchema(schema_read_)) {}
+  MapsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::MapsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::MapsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  MapsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::MapsReaderBase::VersionFromSchema(schema_read_)) {}
+  MapsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::MapsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::MapsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1010,11 +1010,11 @@ class UnionsWriter : public test_model::UnionsWriterBase, yardl::binary::BinaryW
 // Binary reader for the Unions protocol.
 class UnionsReader : public test_model::UnionsReaderBase, yardl::binary::BinaryReader {
   public:
-  UnionsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::UnionsReaderBase::VersionFromSchema(schema_read_)) {}
+  UnionsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::UnionsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::UnionsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  UnionsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::UnionsReaderBase::VersionFromSchema(schema_read_)) {}
+  UnionsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::UnionsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::UnionsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1057,11 +1057,11 @@ class StreamsOfUnionsWriter : public test_model::StreamsOfUnionsWriterBase, yard
 // Binary reader for the StreamsOfUnions protocol.
 class StreamsOfUnionsReader : public test_model::StreamsOfUnionsReaderBase, yardl::binary::BinaryReader {
   public:
-  StreamsOfUnionsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::StreamsOfUnionsReaderBase::VersionFromSchema(schema_read_)) {}
+  StreamsOfUnionsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::StreamsOfUnionsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::StreamsOfUnionsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  StreamsOfUnionsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::StreamsOfUnionsReaderBase::VersionFromSchema(schema_read_)) {}
+  StreamsOfUnionsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::StreamsOfUnionsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::StreamsOfUnionsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1104,11 +1104,11 @@ class EnumsWriter : public test_model::EnumsWriterBase, yardl::binary::BinaryWri
 // Binary reader for the Enums protocol.
 class EnumsReader : public test_model::EnumsReaderBase, yardl::binary::BinaryReader {
   public:
-  EnumsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::EnumsReaderBase::VersionFromSchema(schema_read_)) {}
+  EnumsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::EnumsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::EnumsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  EnumsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::EnumsReaderBase::VersionFromSchema(schema_read_)) {}
+  EnumsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::EnumsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::EnumsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1148,11 +1148,11 @@ class FlagsWriter : public test_model::FlagsWriterBase, yardl::binary::BinaryWri
 // Binary reader for the Flags protocol.
 class FlagsReader : public test_model::FlagsReaderBase, yardl::binary::BinaryReader {
   public:
-  FlagsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::FlagsReaderBase::VersionFromSchema(schema_read_)) {}
+  FlagsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::FlagsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::FlagsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  FlagsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::FlagsReaderBase::VersionFromSchema(schema_read_)) {}
+  FlagsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::FlagsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::FlagsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1194,11 +1194,11 @@ class StateTestWriter : public test_model::StateTestWriterBase, yardl::binary::B
 // Binary reader for the StateTest protocol.
 class StateTestReader : public test_model::StateTestReaderBase, yardl::binary::BinaryReader {
   public:
-  StateTestReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::StateTestReaderBase::VersionFromSchema(schema_read_)) {}
+  StateTestReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::StateTestReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::StateTestReaderBase::VersionFromSchema(schema_read_)) {}
 
-  StateTestReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::StateTestReaderBase::VersionFromSchema(schema_read_)) {}
+  StateTestReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::StateTestReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::StateTestReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1246,11 +1246,11 @@ class SimpleGenericsWriter : public test_model::SimpleGenericsWriterBase, yardl:
 // Binary reader for the SimpleGenerics protocol.
 class SimpleGenericsReader : public test_model::SimpleGenericsReaderBase, yardl::binary::BinaryReader {
   public:
-  SimpleGenericsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::SimpleGenericsReaderBase::VersionFromSchema(schema_read_)) {}
+  SimpleGenericsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::SimpleGenericsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::SimpleGenericsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  SimpleGenericsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::SimpleGenericsReaderBase::VersionFromSchema(schema_read_)) {}
+  SimpleGenericsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::SimpleGenericsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::SimpleGenericsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1298,11 +1298,11 @@ class AdvancedGenericsWriter : public test_model::AdvancedGenericsWriterBase, ya
 // Binary reader for the AdvancedGenerics protocol.
 class AdvancedGenericsReader : public test_model::AdvancedGenericsReaderBase, yardl::binary::BinaryReader {
   public:
-  AdvancedGenericsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::AdvancedGenericsReaderBase::VersionFromSchema(schema_read_)) {}
+  AdvancedGenericsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::AdvancedGenericsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::AdvancedGenericsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  AdvancedGenericsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::AdvancedGenericsReaderBase::VersionFromSchema(schema_read_)) {}
+  AdvancedGenericsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::AdvancedGenericsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::AdvancedGenericsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1350,11 +1350,11 @@ class AliasesWriter : public test_model::AliasesWriterBase, yardl::binary::Binar
 // Binary reader for the Aliases protocol.
 class AliasesReader : public test_model::AliasesReaderBase, yardl::binary::BinaryReader {
   public:
-  AliasesReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::AliasesReaderBase::VersionFromSchema(schema_read_)) {}
+  AliasesReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::AliasesReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::AliasesReaderBase::VersionFromSchema(schema_read_)) {}
 
-  AliasesReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::AliasesReaderBase::VersionFromSchema(schema_read_)) {}
+  AliasesReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::AliasesReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::AliasesReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1405,11 +1405,11 @@ class StreamsOfAliasedUnionsWriter : public test_model::StreamsOfAliasedUnionsWr
 // Binary reader for the StreamsOfAliasedUnions protocol.
 class StreamsOfAliasedUnionsReader : public test_model::StreamsOfAliasedUnionsReaderBase, yardl::binary::BinaryReader {
   public:
-  StreamsOfAliasedUnionsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::StreamsOfAliasedUnionsReaderBase::VersionFromSchema(schema_read_)) {}
+  StreamsOfAliasedUnionsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::StreamsOfAliasedUnionsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::StreamsOfAliasedUnionsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  StreamsOfAliasedUnionsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::StreamsOfAliasedUnionsReaderBase::VersionFromSchema(schema_read_)) {}
+  StreamsOfAliasedUnionsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::StreamsOfAliasedUnionsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::StreamsOfAliasedUnionsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1447,11 +1447,11 @@ class ProtocolWithComputedFieldsWriter : public test_model::ProtocolWithComputed
 // Binary reader for the ProtocolWithComputedFields protocol.
 class ProtocolWithComputedFieldsReader : public test_model::ProtocolWithComputedFieldsReaderBase, yardl::binary::BinaryReader {
   public:
-  ProtocolWithComputedFieldsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::ProtocolWithComputedFieldsReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithComputedFieldsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::ProtocolWithComputedFieldsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::ProtocolWithComputedFieldsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ProtocolWithComputedFieldsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::ProtocolWithComputedFieldsReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithComputedFieldsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::ProtocolWithComputedFieldsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::ProtocolWithComputedFieldsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1486,11 +1486,11 @@ class ProtocolWithKeywordStepsWriter : public test_model::ProtocolWithKeywordSte
 // Binary reader for the ProtocolWithKeywordSteps protocol.
 class ProtocolWithKeywordStepsReader : public test_model::ProtocolWithKeywordStepsReaderBase, yardl::binary::BinaryReader {
   public:
-  ProtocolWithKeywordStepsReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::ProtocolWithKeywordStepsReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithKeywordStepsReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::ProtocolWithKeywordStepsReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::ProtocolWithKeywordStepsReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ProtocolWithKeywordStepsReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::ProtocolWithKeywordStepsReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithKeywordStepsReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::ProtocolWithKeywordStepsReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::ProtocolWithKeywordStepsReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 
@@ -1527,11 +1527,11 @@ class ProtocolWithOptionalDateWriter : public test_model::ProtocolWithOptionalDa
 // Binary reader for the ProtocolWithOptionalDate protocol.
 class ProtocolWithOptionalDateReader : public test_model::ProtocolWithOptionalDateReaderBase, yardl::binary::BinaryReader {
   public:
-  ProtocolWithOptionalDateReader(std::istream& stream)
-      : yardl::binary::BinaryReader(stream), version_(test_model::ProtocolWithOptionalDateReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithOptionalDateReader(std::istream& stream, bool skip_completed_check=false)
+      : test_model::ProtocolWithOptionalDateReaderBase(skip_completed_check), yardl::binary::BinaryReader(stream), version_(test_model::ProtocolWithOptionalDateReaderBase::VersionFromSchema(schema_read_)) {}
 
-  ProtocolWithOptionalDateReader(std::string file_name)
-      : yardl::binary::BinaryReader(file_name), version_(test_model::ProtocolWithOptionalDateReaderBase::VersionFromSchema(schema_read_)) {}
+  ProtocolWithOptionalDateReader(std::string file_name, bool skip_completed_check=false)
+      : test_model::ProtocolWithOptionalDateReaderBase(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(test_model::ProtocolWithOptionalDateReaderBase::VersionFromSchema(schema_read_)) {}
 
   Version GetVersion() { return version_; }
 

--- a/cpp/test/generated/protocols.cc
+++ b/cpp/test/generated/protocols.cc
@@ -153,7 +153,7 @@ bool BenchmarkFloat256x256ReaderBase::ReadFloat256x256Impl(std::vector<yardl::Fi
 }
 
 void BenchmarkFloat256x256ReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     if (state_ == 1) {
       state_ = 2;
     } else {
@@ -324,7 +324,7 @@ bool BenchmarkInt256x256ReaderBase::ReadInt256x256Impl(std::vector<yardl::FixedN
 }
 
 void BenchmarkInt256x256ReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     if (state_ == 1) {
       state_ = 2;
     } else {
@@ -495,7 +495,7 @@ bool BenchmarkFloatVlenReaderBase::ReadFloatArrayImpl(std::vector<yardl::NDArray
 }
 
 void BenchmarkFloatVlenReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     if (state_ == 1) {
       state_ = 2;
     } else {
@@ -666,7 +666,7 @@ bool BenchmarkSmallRecordReaderBase::ReadSmallRecordImpl(std::vector<test_model:
 }
 
 void BenchmarkSmallRecordReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     if (state_ == 1) {
       state_ = 2;
     } else {
@@ -837,7 +837,7 @@ bool BenchmarkSmallRecordWithOptionalsReaderBase::ReadSmallRecordImpl(std::vecto
 }
 
 void BenchmarkSmallRecordWithOptionalsReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     if (state_ == 1) {
       state_ = 2;
     } else {
@@ -1008,7 +1008,7 @@ bool BenchmarkSimpleMrdReaderBase::ReadDataImpl(std::vector<std::variant<test_mo
 }
 
 void BenchmarkSimpleMrdReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     if (state_ == 1) {
       state_ = 2;
     } else {
@@ -1132,7 +1132,7 @@ void ScalarsReaderBase::ReadRecord(test_model::RecordWithPrimitives& value) {
 }
 
 void ScalarsReaderBase::Close() {
-  if (unlikely(state_ != 4)) {
+  if (!skip_completed_check_ && unlikely(state_ != 4)) {
     ScalarsReaderBaseInvalidState(4, state_);
   }
 
@@ -1290,7 +1290,7 @@ void ScalarOptionalsReaderBase::ReadOptionalRecordWithOptionalFields(std::option
 }
 
 void ScalarOptionalsReaderBase::Close() {
-  if (unlikely(state_ != 8)) {
+  if (!skip_completed_check_ && unlikely(state_ != 8)) {
     ScalarOptionalsReaderBaseInvalidState(8, state_);
   }
 
@@ -1395,7 +1395,7 @@ void NestedRecordsReaderBase::ReadTupleWithRecords(test_model::TupleWithRecords&
 }
 
 void NestedRecordsReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     NestedRecordsReaderBaseInvalidState(2, state_);
   }
 
@@ -1548,7 +1548,7 @@ void VlensReaderBase::ReadVlenOfRecordWithVlens(std::vector<test_model::RecordWi
 }
 
 void VlensReaderBase::Close() {
-  if (unlikely(state_ != 8)) {
+  if (!skip_completed_check_ && unlikely(state_ != 8)) {
     VlensReaderBaseInvalidState(8, state_);
   }
 
@@ -1674,7 +1674,7 @@ void StringsReaderBase::ReadRecWithString(test_model::RecordWithStrings& value) 
 }
 
 void StringsReaderBase::Close() {
-  if (unlikely(state_ != 4)) {
+  if (!skip_completed_check_ && unlikely(state_ != 4)) {
     StringsReaderBaseInvalidState(4, state_);
   }
 
@@ -1769,7 +1769,7 @@ void OptionalVectorsReaderBase::ReadRecordWithOptionalVector(test_model::RecordW
 }
 
 void OptionalVectorsReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     OptionalVectorsReaderBaseInvalidState(2, state_);
   }
 
@@ -1922,7 +1922,7 @@ void FixedVectorsReaderBase::ReadRecordWithFixedVectors(test_model::RecordWithFi
 }
 
 void FixedVectorsReaderBase::Close() {
-  if (unlikely(state_ != 8)) {
+  if (!skip_completed_check_ && unlikely(state_ != 8)) {
     FixedVectorsReaderBaseInvalidState(8, state_);
   }
 
@@ -2386,7 +2386,7 @@ bool StreamsReaderBase::ReadFixedVectorImpl(std::vector<std::array<int32_t, 3>>&
 }
 
 void StreamsReaderBase::Close() {
-  if (unlikely(state_ != 8)) {
+  if (!skip_completed_check_ && unlikely(state_ != 8)) {
     if (state_ == 7) {
       state_ = 8;
     } else {
@@ -2615,7 +2615,7 @@ void FixedArraysReaderBase::ReadNamedArray(test_model::NamedFixedNDArray& value)
 }
 
 void FixedArraysReaderBase::Close() {
-  if (unlikely(state_ != 10)) {
+  if (!skip_completed_check_ && unlikely(state_ != 10)) {
     FixedArraysReaderBaseInvalidState(10, state_);
   }
 
@@ -2893,7 +2893,7 @@ void SubarraysReaderBase::ReadGenericSubarray(test_model::Image<yardl::FixedNDAr
 }
 
 void SubarraysReaderBase::Close() {
-  if (unlikely(state_ != 18)) {
+  if (!skip_completed_check_ && unlikely(state_ != 18)) {
     SubarraysReaderBaseInvalidState(18, state_);
   }
 
@@ -3044,7 +3044,7 @@ void SubarraysInRecordsReaderBase::ReadWithVlenSubarrays(yardl::DynamicNDArray<t
 }
 
 void SubarraysInRecordsReaderBase::Close() {
-  if (unlikely(state_ != 4)) {
+  if (!skip_completed_check_ && unlikely(state_ != 4)) {
     SubarraysInRecordsReaderBaseInvalidState(4, state_);
   }
 
@@ -3223,7 +3223,7 @@ void NDArraysReaderBase::ReadNamedArray(test_model::NamedNDArray& value) {
 }
 
 void NDArraysReaderBase::Close() {
-  if (unlikely(state_ != 10)) {
+  if (!skip_completed_check_ && unlikely(state_ != 10)) {
     NDArraysReaderBaseInvalidState(10, state_);
   }
 
@@ -3396,7 +3396,7 @@ void NDArraysSingleDimensionReaderBase::ReadRecordWithNDArrays(test_model::Recor
 }
 
 void NDArraysSingleDimensionReaderBase::Close() {
-  if (unlikely(state_ != 8)) {
+  if (!skip_completed_check_ && unlikely(state_ != 8)) {
     NDArraysSingleDimensionReaderBaseInvalidState(8, state_);
   }
 
@@ -3564,7 +3564,7 @@ void DynamicNDArraysReaderBase::ReadRecordWithDynamicNDArrays(test_model::Record
 }
 
 void DynamicNDArraysReaderBase::Close() {
-  if (unlikely(state_ != 8)) {
+  if (!skip_completed_check_ && unlikely(state_ != 8)) {
     DynamicNDArraysReaderBaseInvalidState(8, state_);
   }
 
@@ -3834,7 +3834,7 @@ bool MultiDArraysReaderBase::ReadFramesImpl(std::vector<yardl::FixedNDArray<floa
 }
 
 void MultiDArraysReaderBase::Close() {
-  if (unlikely(state_ != 4)) {
+  if (!skip_completed_check_ && unlikely(state_ != 4)) {
     if (state_ == 3) {
       state_ = 4;
     } else {
@@ -3972,7 +3972,7 @@ void ComplexArraysReaderBase::ReadDoubles(yardl::NDArray<std::complex<double>, 2
 }
 
 void ComplexArraysReaderBase::Close() {
-  if (unlikely(state_ != 4)) {
+  if (!skip_completed_check_ && unlikely(state_ != 4)) {
     ComplexArraysReaderBaseInvalidState(4, state_);
   }
 
@@ -4151,7 +4151,7 @@ void MapsReaderBase::ReadRecords(std::vector<test_model::RecordWithMaps>& value)
 }
 
 void MapsReaderBase::Close() {
-  if (unlikely(state_ != 10)) {
+  if (!skip_completed_check_ && unlikely(state_ != 10)) {
     MapsReaderBaseInvalidState(10, state_);
   }
 
@@ -4324,7 +4324,7 @@ void UnionsReaderBase::ReadRecordWithUnions(basic_types::RecordWithUnions& value
 }
 
 void UnionsReaderBase::Close() {
-  if (unlikely(state_ != 8)) {
+  if (!skip_completed_check_ && unlikely(state_ != 8)) {
     UnionsReaderBaseInvalidState(8, state_);
   }
 
@@ -4691,7 +4691,7 @@ bool StreamsOfUnionsReaderBase::ReadManyCasesImpl(std::vector<std::variant<int32
 }
 
 void StreamsOfUnionsReaderBase::Close() {
-  if (unlikely(state_ != 6)) {
+  if (!skip_completed_check_ && unlikely(state_ != 6)) {
     if (state_ == 5) {
       state_ = 6;
     } else {
@@ -4885,7 +4885,7 @@ void EnumsReaderBase::ReadRec(test_model::RecordWithEnums& value) {
 }
 
 void EnumsReaderBase::Close() {
-  if (unlikely(state_ != 8)) {
+  if (!skip_completed_check_ && unlikely(state_ != 8)) {
     EnumsReaderBaseInvalidState(8, state_);
   }
 
@@ -5155,7 +5155,7 @@ bool FlagsReaderBase::ReadFormatsImpl(std::vector<test_model::TextFormat>& value
 }
 
 void FlagsReaderBase::Close() {
-  if (unlikely(state_ != 4)) {
+  if (!skip_completed_check_ && unlikely(state_ != 4)) {
     if (state_ == 3) {
       state_ = 4;
     } else {
@@ -5386,7 +5386,7 @@ void StateTestReaderBase::ReadAnotherInt(int32_t& value) {
 }
 
 void StateTestReaderBase::Close() {
-  if (unlikely(state_ != 6)) {
+  if (!skip_completed_check_ && unlikely(state_ != 6)) {
     StateTestReaderBaseInvalidState(6, state_);
   }
 
@@ -5731,7 +5731,7 @@ bool SimpleGenericsReaderBase::ReadStreamOfTypeVariantsImpl(std::vector<std::var
 }
 
 void SimpleGenericsReaderBase::Close() {
-  if (unlikely(state_ != 18)) {
+  if (!skip_completed_check_ && unlikely(state_ != 18)) {
     if (state_ == 17) {
       state_ = 18;
     } else {
@@ -5958,7 +5958,7 @@ void AdvancedGenericsReaderBase::ReadTupleOfVectors(test_model::MyTuple<std::vec
 }
 
 void AdvancedGenericsReaderBase::Close() {
-  if (unlikely(state_ != 10)) {
+  if (!skip_completed_check_ && unlikely(state_ != 10)) {
     AdvancedGenericsReaderBaseInvalidState(10, state_);
   }
 
@@ -6350,7 +6350,7 @@ void AliasesReaderBase::ReadVectors(std::vector<test_model::RecordContainingVect
 }
 
 void AliasesReaderBase::Close() {
-  if (unlikely(state_ != 22)) {
+  if (!skip_completed_check_ && unlikely(state_ != 22)) {
     AliasesReaderBaseInvalidState(22, state_);
   }
 
@@ -6664,7 +6664,7 @@ bool StreamsOfAliasedUnionsReaderBase::ReadNullableIntOrSimpleRecordImpl(std::ve
 }
 
 void StreamsOfAliasedUnionsReaderBase::Close() {
-  if (unlikely(state_ != 4)) {
+  if (!skip_completed_check_ && unlikely(state_ != 4)) {
     if (state_ == 3) {
       state_ = 4;
     } else {
@@ -6781,7 +6781,7 @@ void ProtocolWithComputedFieldsReaderBase::ReadRecordWithComputedFields(test_mod
 }
 
 void ProtocolWithComputedFieldsReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     ProtocolWithComputedFieldsReaderBaseInvalidState(2, state_);
   }
 
@@ -6964,7 +6964,7 @@ void ProtocolWithKeywordStepsReaderBase::ReadFloat(test_model::EnumWithKeywordSy
 }
 
 void ProtocolWithKeywordStepsReaderBase::Close() {
-  if (unlikely(state_ != 4)) {
+  if (!skip_completed_check_ && unlikely(state_ != 4)) {
     ProtocolWithKeywordStepsReaderBaseInvalidState(4, state_);
   }
 
@@ -7068,7 +7068,7 @@ void ProtocolWithOptionalDateReaderBase::ReadRecord(std::optional<test_model::Re
 }
 
 void ProtocolWithOptionalDateReaderBase::Close() {
-  if (unlikely(state_ != 2)) {
+  if (!skip_completed_check_ && unlikely(state_ != 2)) {
     ProtocolWithOptionalDateReaderBaseInvalidState(2, state_);
   }
 

--- a/cpp/test/generated/protocols.h
+++ b/cpp/test/generated/protocols.h
@@ -50,6 +50,8 @@ class BenchmarkFloat256x256WriterBase {
 // Abstract reader for the BenchmarkFloat256x256 protocol.
 class BenchmarkFloat256x256ReaderBase {
   public:
+  BenchmarkFloat256x256ReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadFloat256x256(yardl::FixedNDArray<float, 256, 256>& value);
 
@@ -72,6 +74,8 @@ class BenchmarkFloat256x256ReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -120,6 +124,8 @@ class BenchmarkInt256x256WriterBase {
 // Abstract reader for the BenchmarkInt256x256 protocol.
 class BenchmarkInt256x256ReaderBase {
   public:
+  BenchmarkInt256x256ReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadInt256x256(yardl::FixedNDArray<int32_t, 256, 256>& value);
 
@@ -142,6 +148,8 @@ class BenchmarkInt256x256ReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -190,6 +198,8 @@ class BenchmarkFloatVlenWriterBase {
 // Abstract reader for the BenchmarkFloatVlen protocol.
 class BenchmarkFloatVlenReaderBase {
   public:
+  BenchmarkFloatVlenReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadFloatArray(yardl::NDArray<float, 2>& value);
 
@@ -212,6 +222,8 @@ class BenchmarkFloatVlenReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -260,6 +272,8 @@ class BenchmarkSmallRecordWriterBase {
 // Abstract reader for the BenchmarkSmallRecord protocol.
 class BenchmarkSmallRecordReaderBase {
   public:
+  BenchmarkSmallRecordReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadSmallRecord(test_model::SmallBenchmarkRecord& value);
 
@@ -282,6 +296,8 @@ class BenchmarkSmallRecordReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -330,6 +346,8 @@ class BenchmarkSmallRecordWithOptionalsWriterBase {
 // Abstract reader for the BenchmarkSmallRecordWithOptionals protocol.
 class BenchmarkSmallRecordWithOptionalsReaderBase {
   public:
+  BenchmarkSmallRecordWithOptionalsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadSmallRecord(test_model::SimpleEncodingCounters& value);
 
@@ -352,6 +370,8 @@ class BenchmarkSmallRecordWithOptionalsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -400,6 +420,8 @@ class BenchmarkSimpleMrdWriterBase {
 // Abstract reader for the BenchmarkSimpleMrd protocol.
 class BenchmarkSimpleMrdReaderBase {
   public:
+  BenchmarkSimpleMrdReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadData(std::variant<test_model::SimpleAcquisition, image::Image<float>>& value);
 
@@ -422,6 +444,8 @@ class BenchmarkSimpleMrdReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -464,6 +488,8 @@ class ScalarsWriterBase {
 // Abstract reader for the Scalars protocol.
 class ScalarsReaderBase {
   public:
+  ScalarsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadInt32(int32_t& value);
 
@@ -486,6 +512,8 @@ class ScalarsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -536,6 +564,8 @@ class ScalarOptionalsWriterBase {
 // Abstract reader for the ScalarOptionals protocol.
 class ScalarOptionalsReaderBase {
   public:
+  ScalarOptionalsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadOptionalInt(std::optional<int32_t>& value);
 
@@ -566,6 +596,8 @@ class ScalarOptionalsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -604,6 +636,8 @@ class NestedRecordsWriterBase {
 // Abstract reader for the NestedRecords protocol.
 class NestedRecordsReaderBase {
   public:
+  NestedRecordsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadTupleWithRecords(test_model::TupleWithRecords& value);
 
@@ -622,6 +656,8 @@ class NestedRecordsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -672,6 +708,8 @@ class VlensWriterBase {
 // Abstract reader for the Vlens protocol.
 class VlensReaderBase {
   public:
+  VlensReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadIntVector(std::vector<int32_t>& value);
 
@@ -702,6 +740,8 @@ class VlensReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -744,6 +784,8 @@ class StringsWriterBase {
 // Abstract reader for the Strings protocol.
 class StringsReaderBase {
   public:
+  StringsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadSingleString(std::string& value);
 
@@ -766,6 +808,8 @@ class StringsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -804,6 +848,8 @@ class OptionalVectorsWriterBase {
 // Abstract reader for the OptionalVectors protocol.
 class OptionalVectorsReaderBase {
   public:
+  OptionalVectorsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadRecordWithOptionalVector(test_model::RecordWithOptionalVector& value);
 
@@ -822,6 +868,8 @@ class OptionalVectorsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -872,6 +920,8 @@ class FixedVectorsWriterBase {
 // Abstract reader for the FixedVectors protocol.
 class FixedVectorsReaderBase {
   public:
+  FixedVectorsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadFixedIntVector(std::array<int32_t, 5>& value);
 
@@ -902,6 +952,8 @@ class FixedVectorsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -992,6 +1044,8 @@ class StreamsWriterBase {
 // Abstract reader for the Streams protocol.
 class StreamsReaderBase {
   public:
+  StreamsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadIntData(int32_t& value);
 
@@ -1038,6 +1092,8 @@ class StreamsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1092,6 +1148,8 @@ class FixedArraysWriterBase {
 // Abstract reader for the FixedArrays protocol.
 class FixedArraysReaderBase {
   public:
+  FixedArraysReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadInts(yardl::FixedNDArray<int32_t, 2, 3>& value);
 
@@ -1126,6 +1184,8 @@ class FixedArraysReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1196,6 +1256,8 @@ class SubarraysWriterBase {
 // Abstract reader for the Subarrays protocol.
 class SubarraysReaderBase {
   public:
+  SubarraysReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadDynamicWithFixedIntSubarray(yardl::DynamicNDArray<yardl::FixedNDArray<int32_t, 3>>& value);
 
@@ -1247,6 +1309,8 @@ class SubarraysReaderBase {
 
   static Version VersionFromSchema(const std::string& schema);
 
+  bool skip_completed_check_;
+
   private:
   uint8_t state_ = 0;
 };
@@ -1288,6 +1352,8 @@ class SubarraysInRecordsWriterBase {
 // Abstract reader for the SubarraysInRecords protocol.
 class SubarraysInRecordsReaderBase {
   public:
+  SubarraysInRecordsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadWithFixedSubarrays(yardl::DynamicNDArray<test_model::RecordWithFixedCollections>& value);
 
@@ -1310,6 +1376,8 @@ class SubarraysInRecordsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1364,6 +1432,8 @@ class NDArraysWriterBase {
 // Abstract reader for the NDArrays protocol.
 class NDArraysReaderBase {
   public:
+  NDArraysReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadInts(yardl::NDArray<int32_t, 2>& value);
 
@@ -1398,6 +1468,8 @@ class NDArraysReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1448,6 +1520,8 @@ class NDArraysSingleDimensionWriterBase {
 // Abstract reader for the NDArraysSingleDimension protocol.
 class NDArraysSingleDimensionReaderBase {
   public:
+  NDArraysSingleDimensionReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadInts(yardl::NDArray<int32_t, 1>& value);
 
@@ -1478,6 +1552,8 @@ class NDArraysSingleDimensionReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1528,6 +1604,8 @@ class DynamicNDArraysWriterBase {
 // Abstract reader for the DynamicNDArrays protocol.
 class DynamicNDArraysReaderBase {
   public:
+  DynamicNDArraysReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadInts(yardl::DynamicNDArray<int32_t>& value);
 
@@ -1558,6 +1636,8 @@ class DynamicNDArraysReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1620,6 +1700,8 @@ class MultiDArraysWriterBase {
 // Abstract reader for the MultiDArrays protocol.
 class MultiDArraysReaderBase {
   public:
+  MultiDArraysReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadImages(yardl::NDArray<float, 4>& value);
 
@@ -1650,6 +1732,8 @@ class MultiDArraysReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1692,6 +1776,8 @@ class ComplexArraysWriterBase {
 // Abstract reader for the ComplexArrays protocol.
 class ComplexArraysReaderBase {
   public:
+  ComplexArraysReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadFloats(yardl::DynamicNDArray<std::complex<float>>& value);
 
@@ -1714,6 +1800,8 @@ class ComplexArraysReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1768,6 +1856,8 @@ class MapsWriterBase {
 // Abstract reader for the Maps protocol.
 class MapsReaderBase {
   public:
+  MapsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadStringToInt(std::unordered_map<std::string, int32_t>& value);
 
@@ -1802,6 +1892,8 @@ class MapsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1852,6 +1944,8 @@ class UnionsWriterBase {
 // Abstract reader for the Unions protocol.
 class UnionsReaderBase {
   public:
+  UnionsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadIntOrSimpleRecord(std::variant<int32_t, test_model::SimpleRecord>& value);
 
@@ -1882,6 +1976,8 @@ class UnionsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -1958,6 +2054,8 @@ class StreamsOfUnionsWriterBase {
 // Abstract reader for the StreamsOfUnions protocol.
 class StreamsOfUnionsReaderBase {
   public:
+  StreamsOfUnionsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadIntOrSimpleRecord(std::variant<int32_t, test_model::SimpleRecord>& value);
 
@@ -1996,6 +2094,8 @@ class StreamsOfUnionsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -2046,6 +2146,8 @@ class EnumsWriterBase {
 // Abstract reader for the Enums protocol.
 class EnumsReaderBase {
   public:
+  EnumsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadSingle(test_model::Fruits& value);
 
@@ -2076,6 +2178,8 @@ class EnumsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -2138,6 +2242,8 @@ class FlagsWriterBase {
 // Abstract reader for the Flags protocol.
 class FlagsReaderBase {
   public:
+  FlagsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadDays(test_model::DaysOfWeek& value);
 
@@ -2168,6 +2274,8 @@ class FlagsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -2224,6 +2332,8 @@ class StateTestWriterBase {
 // Abstract reader for the StateTest protocol.
 class StateTestReaderBase {
   public:
+  StateTestReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadAnInt(int32_t& value);
 
@@ -2254,6 +2364,8 @@ class StateTestReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -2334,6 +2446,8 @@ class SimpleGenericsWriterBase {
 // Abstract reader for the SimpleGenerics protocol.
 class SimpleGenericsReaderBase {
   public:
+  SimpleGenericsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadFloatImage(image::FloatImage& value);
 
@@ -2389,6 +2503,8 @@ class SimpleGenericsReaderBase {
 
   static Version VersionFromSchema(const std::string& schema);
 
+  bool skip_completed_check_;
+
   private:
   uint8_t state_ = 0;
 };
@@ -2442,6 +2558,8 @@ class AdvancedGenericsWriterBase {
 // Abstract reader for the AdvancedGenerics protocol.
 class AdvancedGenericsReaderBase {
   public:
+  AdvancedGenericsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadFloatImageImage(test_model::Image<test_model::Image<float>>& value);
 
@@ -2476,6 +2594,8 @@ class AdvancedGenericsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -2564,6 +2684,8 @@ class AliasesWriterBase {
 // Abstract reader for the Aliases protocol.
 class AliasesReaderBase {
   public:
+  AliasesReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadAliasedString(test_model::AliasedString& value);
 
@@ -2627,6 +2749,8 @@ class AliasesReaderBase {
 
   static Version VersionFromSchema(const std::string& schema);
 
+  bool skip_completed_check_;
+
   private:
   uint8_t state_ = 0;
 };
@@ -2688,6 +2812,8 @@ class StreamsOfAliasedUnionsWriterBase {
 // Abstract reader for the StreamsOfAliasedUnions protocol.
 class StreamsOfAliasedUnionsReaderBase {
   public:
+  StreamsOfAliasedUnionsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadIntOrSimpleRecord(test_model::AliasedIntOrSimpleRecord& value);
 
@@ -2718,6 +2844,8 @@ class StreamsOfAliasedUnionsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -2756,6 +2884,8 @@ class ProtocolWithComputedFieldsWriterBase {
 // Abstract reader for the ProtocolWithComputedFields protocol.
 class ProtocolWithComputedFieldsReaderBase {
   public:
+  ProtocolWithComputedFieldsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadRecordWithComputedFields(test_model::RecordWithComputedFields& value);
 
@@ -2774,6 +2904,8 @@ class ProtocolWithComputedFieldsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -2826,6 +2958,8 @@ class ProtocolWithKeywordStepsWriterBase {
 // Abstract reader for the ProtocolWithKeywordSteps protocol.
 class ProtocolWithKeywordStepsReaderBase {
   public:
+  ProtocolWithKeywordStepsReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   [[nodiscard]] bool ReadInt(test_model::RecordWithKeywordFields& value);
 
@@ -2852,6 +2986,8 @@ class ProtocolWithKeywordStepsReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;
@@ -2890,6 +3026,8 @@ class ProtocolWithOptionalDateWriterBase {
 // Abstract reader for the ProtocolWithOptionalDate protocol.
 class ProtocolWithOptionalDateReaderBase {
   public:
+  ProtocolWithOptionalDateReaderBase(bool skip_completed_check = false): skip_completed_check_(skip_completed_check) {}
+
   // Ordinal 0.
   void ReadRecord(std::optional<test_model::RecordWithOptionalDate>& value);
 
@@ -2908,6 +3046,8 @@ class ProtocolWithOptionalDateReaderBase {
   static std::vector<std::string> previous_schemas_;
 
   static Version VersionFromSchema(const std::string& schema);
+
+  bool skip_completed_check_;
 
   private:
   uint8_t state_ = 0;

--- a/matlab/generated/+sandbox/+binary/HelloWorldReader.m
+++ b/matlab/generated/+sandbox/+binary/HelloWorldReader.m
@@ -7,8 +7,12 @@ classdef HelloWorldReader < yardl.binary.BinaryProtocolReader & sandbox.HelloWor
   end
 
   methods
-    function self = HelloWorldReader(filename)
-      self@sandbox.HelloWorldReaderBase();
+    function self = HelloWorldReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@sandbox.HelloWorldReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, sandbox.HelloWorldReaderBase.schema);
       self.data_serializer = yardl.binary.StreamSerializer(yardl.binary.FixedNDArraySerializer(yardl.binary.Complexfloat64Serializer, [2]));
     end

--- a/matlab/generated/+sandbox/HelloWorldReaderBase.m
+++ b/matlab/generated/+sandbox/HelloWorldReaderBase.m
@@ -3,16 +3,21 @@
 classdef HelloWorldReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = HelloWorldReaderBase()
+    function self = HelloWorldReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/+binary/AdvancedGenericsReader.m
+++ b/matlab/generated/+test_model/+binary/AdvancedGenericsReader.m
@@ -11,8 +11,12 @@ classdef AdvancedGenericsReader < yardl.binary.BinaryProtocolReader & test_model
   end
 
   methods
-    function self = AdvancedGenericsReader(filename)
-      self@test_model.AdvancedGenericsReaderBase();
+    function self = AdvancedGenericsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.AdvancedGenericsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.AdvancedGenericsReaderBase.schema);
       self.float_image_image_serializer = yardl.binary.NDArraySerializer(yardl.binary.NDArraySerializer(yardl.binary.Float32Serializer, 2), 2);
       self.generic_record_1_serializer = test_model.binary.GenericRecordSerializer(yardl.binary.Int32Serializer, yardl.binary.StringSerializer);

--- a/matlab/generated/+test_model/+binary/AliasesReader.m
+++ b/matlab/generated/+test_model/+binary/AliasesReader.m
@@ -17,8 +17,12 @@ classdef AliasesReader < yardl.binary.BinaryProtocolReader & test_model.AliasesR
   end
 
   methods
-    function self = AliasesReader(filename)
-      self@test_model.AliasesReaderBase();
+    function self = AliasesReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.AliasesReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.AliasesReaderBase.schema);
       self.aliased_string_serializer = yardl.binary.StringSerializer;
       self.aliased_enum_serializer = yardl.binary.EnumSerializer('basic_types.Fruits', @basic_types.Fruits, yardl.binary.Int32Serializer);

--- a/matlab/generated/+test_model/+binary/BenchmarkFloat256x256Reader.m
+++ b/matlab/generated/+test_model/+binary/BenchmarkFloat256x256Reader.m
@@ -7,8 +7,12 @@ classdef BenchmarkFloat256x256Reader < yardl.binary.BinaryProtocolReader & test_
   end
 
   methods
-    function self = BenchmarkFloat256x256Reader(filename)
-      self@test_model.BenchmarkFloat256x256ReaderBase();
+    function self = BenchmarkFloat256x256Reader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.BenchmarkFloat256x256ReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.BenchmarkFloat256x256ReaderBase.schema);
       self.float256x256_serializer = yardl.binary.StreamSerializer(yardl.binary.FixedNDArraySerializer(yardl.binary.Float32Serializer, [256, 256]));
     end

--- a/matlab/generated/+test_model/+binary/BenchmarkFloatVlenReader.m
+++ b/matlab/generated/+test_model/+binary/BenchmarkFloatVlenReader.m
@@ -7,8 +7,12 @@ classdef BenchmarkFloatVlenReader < yardl.binary.BinaryProtocolReader & test_mod
   end
 
   methods
-    function self = BenchmarkFloatVlenReader(filename)
-      self@test_model.BenchmarkFloatVlenReaderBase();
+    function self = BenchmarkFloatVlenReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.BenchmarkFloatVlenReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.BenchmarkFloatVlenReaderBase.schema);
       self.float_array_serializer = yardl.binary.StreamSerializer(yardl.binary.NDArraySerializer(yardl.binary.Float32Serializer, 2));
     end

--- a/matlab/generated/+test_model/+binary/BenchmarkInt256x256Reader.m
+++ b/matlab/generated/+test_model/+binary/BenchmarkInt256x256Reader.m
@@ -7,8 +7,12 @@ classdef BenchmarkInt256x256Reader < yardl.binary.BinaryProtocolReader & test_mo
   end
 
   methods
-    function self = BenchmarkInt256x256Reader(filename)
-      self@test_model.BenchmarkInt256x256ReaderBase();
+    function self = BenchmarkInt256x256Reader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.BenchmarkInt256x256ReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.BenchmarkInt256x256ReaderBase.schema);
       self.int256x256_serializer = yardl.binary.StreamSerializer(yardl.binary.FixedNDArraySerializer(yardl.binary.Int32Serializer, [256, 256]));
     end

--- a/matlab/generated/+test_model/+binary/BenchmarkSimpleMrdReader.m
+++ b/matlab/generated/+test_model/+binary/BenchmarkSimpleMrdReader.m
@@ -7,8 +7,12 @@ classdef BenchmarkSimpleMrdReader < yardl.binary.BinaryProtocolReader & test_mod
   end
 
   methods
-    function self = BenchmarkSimpleMrdReader(filename)
-      self@test_model.BenchmarkSimpleMrdReaderBase();
+    function self = BenchmarkSimpleMrdReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.BenchmarkSimpleMrdReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.BenchmarkSimpleMrdReaderBase.schema);
       self.data_serializer = yardl.binary.StreamSerializer(yardl.binary.UnionSerializer('test_model.AcquisitionOrImage', {test_model.binary.SimpleAcquisitionSerializer(), yardl.binary.NDArraySerializer(yardl.binary.Float32Serializer, 2)}, {@test_model.AcquisitionOrImage.Acquisition, @test_model.AcquisitionOrImage.Image}));
     end

--- a/matlab/generated/+test_model/+binary/BenchmarkSmallRecordReader.m
+++ b/matlab/generated/+test_model/+binary/BenchmarkSmallRecordReader.m
@@ -7,8 +7,12 @@ classdef BenchmarkSmallRecordReader < yardl.binary.BinaryProtocolReader & test_m
   end
 
   methods
-    function self = BenchmarkSmallRecordReader(filename)
-      self@test_model.BenchmarkSmallRecordReaderBase();
+    function self = BenchmarkSmallRecordReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.BenchmarkSmallRecordReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.BenchmarkSmallRecordReaderBase.schema);
       self.small_record_serializer = yardl.binary.StreamSerializer(test_model.binary.SmallBenchmarkRecordSerializer());
     end

--- a/matlab/generated/+test_model/+binary/BenchmarkSmallRecordWithOptionalsReader.m
+++ b/matlab/generated/+test_model/+binary/BenchmarkSmallRecordWithOptionalsReader.m
@@ -7,8 +7,12 @@ classdef BenchmarkSmallRecordWithOptionalsReader < yardl.binary.BinaryProtocolRe
   end
 
   methods
-    function self = BenchmarkSmallRecordWithOptionalsReader(filename)
-      self@test_model.BenchmarkSmallRecordWithOptionalsReaderBase();
+    function self = BenchmarkSmallRecordWithOptionalsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.BenchmarkSmallRecordWithOptionalsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.BenchmarkSmallRecordWithOptionalsReaderBase.schema);
       self.small_record_serializer = yardl.binary.StreamSerializer(test_model.binary.SimpleEncodingCountersSerializer());
     end

--- a/matlab/generated/+test_model/+binary/ComplexArraysReader.m
+++ b/matlab/generated/+test_model/+binary/ComplexArraysReader.m
@@ -8,8 +8,12 @@ classdef ComplexArraysReader < yardl.binary.BinaryProtocolReader & test_model.Co
   end
 
   methods
-    function self = ComplexArraysReader(filename)
-      self@test_model.ComplexArraysReaderBase();
+    function self = ComplexArraysReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.ComplexArraysReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.ComplexArraysReaderBase.schema);
       self.floats_serializer = yardl.binary.DynamicNDArraySerializer(yardl.binary.Complexfloat32Serializer);
       self.doubles_serializer = yardl.binary.NDArraySerializer(yardl.binary.Complexfloat64Serializer, 2);

--- a/matlab/generated/+test_model/+binary/DynamicNDArraysReader.m
+++ b/matlab/generated/+test_model/+binary/DynamicNDArraysReader.m
@@ -10,8 +10,12 @@ classdef DynamicNDArraysReader < yardl.binary.BinaryProtocolReader & test_model.
   end
 
   methods
-    function self = DynamicNDArraysReader(filename)
-      self@test_model.DynamicNDArraysReaderBase();
+    function self = DynamicNDArraysReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.DynamicNDArraysReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.DynamicNDArraysReaderBase.schema);
       self.ints_serializer = yardl.binary.DynamicNDArraySerializer(yardl.binary.Int32Serializer);
       self.simple_record_array_serializer = yardl.binary.DynamicNDArraySerializer(test_model.binary.SimpleRecordSerializer());

--- a/matlab/generated/+test_model/+binary/EnumsReader.m
+++ b/matlab/generated/+test_model/+binary/EnumsReader.m
@@ -10,8 +10,12 @@ classdef EnumsReader < yardl.binary.BinaryProtocolReader & test_model.EnumsReade
   end
 
   methods
-    function self = EnumsReader(filename)
-      self@test_model.EnumsReaderBase();
+    function self = EnumsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.EnumsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.EnumsReaderBase.schema);
       self.single_serializer = yardl.binary.EnumSerializer('basic_types.Fruits', @basic_types.Fruits, yardl.binary.Int32Serializer);
       self.vec_serializer = yardl.binary.VectorSerializer(yardl.binary.EnumSerializer('basic_types.Fruits', @basic_types.Fruits, yardl.binary.Int32Serializer));

--- a/matlab/generated/+test_model/+binary/FixedArraysReader.m
+++ b/matlab/generated/+test_model/+binary/FixedArraysReader.m
@@ -11,8 +11,12 @@ classdef FixedArraysReader < yardl.binary.BinaryProtocolReader & test_model.Fixe
   end
 
   methods
-    function self = FixedArraysReader(filename)
-      self@test_model.FixedArraysReaderBase();
+    function self = FixedArraysReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.FixedArraysReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.FixedArraysReaderBase.schema);
       self.ints_serializer = yardl.binary.FixedNDArraySerializer(yardl.binary.Int32Serializer, [3, 2]);
       self.fixed_simple_record_array_serializer = yardl.binary.FixedNDArraySerializer(test_model.binary.SimpleRecordSerializer(), [2, 3]);

--- a/matlab/generated/+test_model/+binary/FixedVectorsReader.m
+++ b/matlab/generated/+test_model/+binary/FixedVectorsReader.m
@@ -10,8 +10,12 @@ classdef FixedVectorsReader < yardl.binary.BinaryProtocolReader & test_model.Fix
   end
 
   methods
-    function self = FixedVectorsReader(filename)
-      self@test_model.FixedVectorsReaderBase();
+    function self = FixedVectorsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.FixedVectorsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.FixedVectorsReaderBase.schema);
       self.fixed_int_vector_serializer = yardl.binary.FixedVectorSerializer(yardl.binary.Int32Serializer, 5);
       self.fixed_simple_record_vector_serializer = yardl.binary.FixedVectorSerializer(test_model.binary.SimpleRecordSerializer(), 3);

--- a/matlab/generated/+test_model/+binary/FlagsReader.m
+++ b/matlab/generated/+test_model/+binary/FlagsReader.m
@@ -8,8 +8,12 @@ classdef FlagsReader < yardl.binary.BinaryProtocolReader & test_model.FlagsReade
   end
 
   methods
-    function self = FlagsReader(filename)
-      self@test_model.FlagsReaderBase();
+    function self = FlagsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.FlagsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.FlagsReaderBase.schema);
       self.days_serializer = yardl.binary.StreamSerializer(yardl.binary.EnumSerializer('basic_types.DaysOfWeek', @basic_types.DaysOfWeek, yardl.binary.Int32Serializer));
       self.formats_serializer = yardl.binary.StreamSerializer(yardl.binary.EnumSerializer('basic_types.TextFormat', @basic_types.TextFormat, yardl.binary.Uint64Serializer));

--- a/matlab/generated/+test_model/+binary/MapsReader.m
+++ b/matlab/generated/+test_model/+binary/MapsReader.m
@@ -11,8 +11,12 @@ classdef MapsReader < yardl.binary.BinaryProtocolReader & test_model.MapsReaderB
   end
 
   methods
-    function self = MapsReader(filename)
-      self@test_model.MapsReaderBase();
+    function self = MapsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.MapsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.MapsReaderBase.schema);
       self.string_to_int_serializer = yardl.binary.MapSerializer(yardl.binary.StringSerializer, yardl.binary.Int32Serializer);
       self.int_to_string_serializer = yardl.binary.MapSerializer(yardl.binary.Int32Serializer, yardl.binary.StringSerializer);

--- a/matlab/generated/+test_model/+binary/MultiDArraysReader.m
+++ b/matlab/generated/+test_model/+binary/MultiDArraysReader.m
@@ -8,8 +8,12 @@ classdef MultiDArraysReader < yardl.binary.BinaryProtocolReader & test_model.Mul
   end
 
   methods
-    function self = MultiDArraysReader(filename)
-      self@test_model.MultiDArraysReaderBase();
+    function self = MultiDArraysReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.MultiDArraysReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.MultiDArraysReaderBase.schema);
       self.images_serializer = yardl.binary.StreamSerializer(yardl.binary.NDArraySerializer(yardl.binary.Float32Serializer, 4));
       self.frames_serializer = yardl.binary.StreamSerializer(yardl.binary.FixedNDArraySerializer(yardl.binary.Float32Serializer, [32, 64, 1, 1]));

--- a/matlab/generated/+test_model/+binary/NDArraysReader.m
+++ b/matlab/generated/+test_model/+binary/NDArraysReader.m
@@ -11,8 +11,12 @@ classdef NDArraysReader < yardl.binary.BinaryProtocolReader & test_model.NDArray
   end
 
   methods
-    function self = NDArraysReader(filename)
-      self@test_model.NDArraysReaderBase();
+    function self = NDArraysReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.NDArraysReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.NDArraysReaderBase.schema);
       self.ints_serializer = yardl.binary.NDArraySerializer(yardl.binary.Int32Serializer, 2);
       self.simple_record_array_serializer = yardl.binary.NDArraySerializer(test_model.binary.SimpleRecordSerializer(), 2);

--- a/matlab/generated/+test_model/+binary/NDArraysSingleDimensionReader.m
+++ b/matlab/generated/+test_model/+binary/NDArraysSingleDimensionReader.m
@@ -10,8 +10,12 @@ classdef NDArraysSingleDimensionReader < yardl.binary.BinaryProtocolReader & tes
   end
 
   methods
-    function self = NDArraysSingleDimensionReader(filename)
-      self@test_model.NDArraysSingleDimensionReaderBase();
+    function self = NDArraysSingleDimensionReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.NDArraysSingleDimensionReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.NDArraysSingleDimensionReaderBase.schema);
       self.ints_serializer = yardl.binary.NDArraySerializer(yardl.binary.Int32Serializer, 1);
       self.simple_record_array_serializer = yardl.binary.NDArraySerializer(test_model.binary.SimpleRecordSerializer(), 1);

--- a/matlab/generated/+test_model/+binary/NestedRecordsReader.m
+++ b/matlab/generated/+test_model/+binary/NestedRecordsReader.m
@@ -7,8 +7,12 @@ classdef NestedRecordsReader < yardl.binary.BinaryProtocolReader & test_model.Ne
   end
 
   methods
-    function self = NestedRecordsReader(filename)
-      self@test_model.NestedRecordsReaderBase();
+    function self = NestedRecordsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.NestedRecordsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.NestedRecordsReaderBase.schema);
       self.tuple_with_records_serializer = test_model.binary.TupleWithRecordsSerializer();
     end

--- a/matlab/generated/+test_model/+binary/OptionalVectorsReader.m
+++ b/matlab/generated/+test_model/+binary/OptionalVectorsReader.m
@@ -7,8 +7,12 @@ classdef OptionalVectorsReader < yardl.binary.BinaryProtocolReader & test_model.
   end
 
   methods
-    function self = OptionalVectorsReader(filename)
-      self@test_model.OptionalVectorsReaderBase();
+    function self = OptionalVectorsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.OptionalVectorsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.OptionalVectorsReaderBase.schema);
       self.record_with_optional_vector_serializer = test_model.binary.RecordWithOptionalVectorSerializer();
     end

--- a/matlab/generated/+test_model/+binary/ProtocolWithComputedFieldsReader.m
+++ b/matlab/generated/+test_model/+binary/ProtocolWithComputedFieldsReader.m
@@ -7,8 +7,12 @@ classdef ProtocolWithComputedFieldsReader < yardl.binary.BinaryProtocolReader & 
   end
 
   methods
-    function self = ProtocolWithComputedFieldsReader(filename)
-      self@test_model.ProtocolWithComputedFieldsReaderBase();
+    function self = ProtocolWithComputedFieldsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.ProtocolWithComputedFieldsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.ProtocolWithComputedFieldsReaderBase.schema);
       self.record_with_computed_fields_serializer = test_model.binary.RecordWithComputedFieldsSerializer();
     end

--- a/matlab/generated/+test_model/+binary/ProtocolWithKeywordStepsReader.m
+++ b/matlab/generated/+test_model/+binary/ProtocolWithKeywordStepsReader.m
@@ -8,8 +8,12 @@ classdef ProtocolWithKeywordStepsReader < yardl.binary.BinaryProtocolReader & te
   end
 
   methods
-    function self = ProtocolWithKeywordStepsReader(filename)
-      self@test_model.ProtocolWithKeywordStepsReaderBase();
+    function self = ProtocolWithKeywordStepsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.ProtocolWithKeywordStepsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.ProtocolWithKeywordStepsReaderBase.schema);
       self.int_serializer = yardl.binary.StreamSerializer(test_model.binary.RecordWithKeywordFieldsSerializer());
       self.float_serializer = yardl.binary.EnumSerializer('test_model.EnumWithKeywordSymbols', @test_model.EnumWithKeywordSymbols, yardl.binary.Int32Serializer);

--- a/matlab/generated/+test_model/+binary/ProtocolWithOptionalDateReader.m
+++ b/matlab/generated/+test_model/+binary/ProtocolWithOptionalDateReader.m
@@ -7,8 +7,12 @@ classdef ProtocolWithOptionalDateReader < yardl.binary.BinaryProtocolReader & te
   end
 
   methods
-    function self = ProtocolWithOptionalDateReader(filename)
-      self@test_model.ProtocolWithOptionalDateReaderBase();
+    function self = ProtocolWithOptionalDateReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.ProtocolWithOptionalDateReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.ProtocolWithOptionalDateReaderBase.schema);
       self.record_serializer = yardl.binary.OptionalSerializer(test_model.binary.RecordWithOptionalDateSerializer());
     end

--- a/matlab/generated/+test_model/+binary/ScalarOptionalsReader.m
+++ b/matlab/generated/+test_model/+binary/ScalarOptionalsReader.m
@@ -10,8 +10,12 @@ classdef ScalarOptionalsReader < yardl.binary.BinaryProtocolReader & test_model.
   end
 
   methods
-    function self = ScalarOptionalsReader(filename)
-      self@test_model.ScalarOptionalsReaderBase();
+    function self = ScalarOptionalsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.ScalarOptionalsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.ScalarOptionalsReaderBase.schema);
       self.optional_int_serializer = yardl.binary.OptionalSerializer(yardl.binary.Int32Serializer);
       self.optional_record_serializer = yardl.binary.OptionalSerializer(test_model.binary.SimpleRecordSerializer());

--- a/matlab/generated/+test_model/+binary/ScalarsReader.m
+++ b/matlab/generated/+test_model/+binary/ScalarsReader.m
@@ -8,8 +8,12 @@ classdef ScalarsReader < yardl.binary.BinaryProtocolReader & test_model.ScalarsR
   end
 
   methods
-    function self = ScalarsReader(filename)
-      self@test_model.ScalarsReaderBase();
+    function self = ScalarsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.ScalarsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.ScalarsReaderBase.schema);
       self.int32_serializer = yardl.binary.Int32Serializer;
       self.record_serializer = test_model.binary.RecordWithPrimitivesSerializer();

--- a/matlab/generated/+test_model/+binary/SimpleGenericsReader.m
+++ b/matlab/generated/+test_model/+binary/SimpleGenericsReader.m
@@ -15,8 +15,12 @@ classdef SimpleGenericsReader < yardl.binary.BinaryProtocolReader & test_model.S
   end
 
   methods
-    function self = SimpleGenericsReader(filename)
-      self@test_model.SimpleGenericsReaderBase();
+    function self = SimpleGenericsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.SimpleGenericsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.SimpleGenericsReaderBase.schema);
       self.float_image_serializer = yardl.binary.NDArraySerializer(yardl.binary.Float32Serializer, 2);
       self.int_image_serializer = yardl.binary.NDArraySerializer(yardl.binary.Int32Serializer, 2);

--- a/matlab/generated/+test_model/+binary/StateTestReader.m
+++ b/matlab/generated/+test_model/+binary/StateTestReader.m
@@ -9,8 +9,12 @@ classdef StateTestReader < yardl.binary.BinaryProtocolReader & test_model.StateT
   end
 
   methods
-    function self = StateTestReader(filename)
-      self@test_model.StateTestReaderBase();
+    function self = StateTestReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.StateTestReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.StateTestReaderBase.schema);
       self.an_int_serializer = yardl.binary.Int32Serializer;
       self.a_stream_serializer = yardl.binary.StreamSerializer(yardl.binary.Int32Serializer);

--- a/matlab/generated/+test_model/+binary/StreamsOfAliasedUnionsReader.m
+++ b/matlab/generated/+test_model/+binary/StreamsOfAliasedUnionsReader.m
@@ -8,8 +8,12 @@ classdef StreamsOfAliasedUnionsReader < yardl.binary.BinaryProtocolReader & test
   end
 
   methods
-    function self = StreamsOfAliasedUnionsReader(filename)
-      self@test_model.StreamsOfAliasedUnionsReaderBase();
+    function self = StreamsOfAliasedUnionsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.StreamsOfAliasedUnionsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.StreamsOfAliasedUnionsReaderBase.schema);
       self.int_or_simple_record_serializer = yardl.binary.StreamSerializer(yardl.binary.UnionSerializer('test_model.AliasedIntOrSimpleRecord', {yardl.binary.Int32Serializer, test_model.binary.SimpleRecordSerializer()}, {@test_model.AliasedIntOrSimpleRecord.Int32, @test_model.AliasedIntOrSimpleRecord.SimpleRecord}));
       self.nullable_int_or_simple_record_serializer = yardl.binary.StreamSerializer(yardl.binary.UnionSerializer('test_model.AliasedNullableIntSimpleRecord', {yardl.binary.NoneSerializer, yardl.binary.Int32Serializer, test_model.binary.SimpleRecordSerializer()}, {yardl.None, @test_model.AliasedNullableIntSimpleRecord.Int32, @test_model.AliasedNullableIntSimpleRecord.SimpleRecord}));

--- a/matlab/generated/+test_model/+binary/StreamsOfUnionsReader.m
+++ b/matlab/generated/+test_model/+binary/StreamsOfUnionsReader.m
@@ -9,8 +9,12 @@ classdef StreamsOfUnionsReader < yardl.binary.BinaryProtocolReader & test_model.
   end
 
   methods
-    function self = StreamsOfUnionsReader(filename)
-      self@test_model.StreamsOfUnionsReaderBase();
+    function self = StreamsOfUnionsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.StreamsOfUnionsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.StreamsOfUnionsReaderBase.schema);
       self.int_or_simple_record_serializer = yardl.binary.StreamSerializer(yardl.binary.UnionSerializer('test_model.Int32OrSimpleRecord', {yardl.binary.Int32Serializer, test_model.binary.SimpleRecordSerializer()}, {@test_model.Int32OrSimpleRecord.Int32, @test_model.Int32OrSimpleRecord.SimpleRecord}));
       self.nullable_int_or_simple_record_serializer = yardl.binary.StreamSerializer(yardl.binary.UnionSerializer('test_model.Int32OrSimpleRecord', {yardl.binary.NoneSerializer, yardl.binary.Int32Serializer, test_model.binary.SimpleRecordSerializer()}, {yardl.None, @test_model.Int32OrSimpleRecord.Int32, @test_model.Int32OrSimpleRecord.SimpleRecord}));

--- a/matlab/generated/+test_model/+binary/StreamsReader.m
+++ b/matlab/generated/+test_model/+binary/StreamsReader.m
@@ -10,8 +10,12 @@ classdef StreamsReader < yardl.binary.BinaryProtocolReader & test_model.StreamsR
   end
 
   methods
-    function self = StreamsReader(filename)
-      self@test_model.StreamsReaderBase();
+    function self = StreamsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.StreamsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.StreamsReaderBase.schema);
       self.int_data_serializer = yardl.binary.StreamSerializer(yardl.binary.Int32Serializer);
       self.optional_int_data_serializer = yardl.binary.StreamSerializer(yardl.binary.OptionalSerializer(yardl.binary.Int32Serializer));

--- a/matlab/generated/+test_model/+binary/StringsReader.m
+++ b/matlab/generated/+test_model/+binary/StringsReader.m
@@ -8,8 +8,12 @@ classdef StringsReader < yardl.binary.BinaryProtocolReader & test_model.StringsR
   end
 
   methods
-    function self = StringsReader(filename)
-      self@test_model.StringsReaderBase();
+    function self = StringsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.StringsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.StringsReaderBase.schema);
       self.single_string_serializer = yardl.binary.StringSerializer;
       self.rec_with_string_serializer = test_model.binary.RecordWithStringsSerializer();

--- a/matlab/generated/+test_model/+binary/SubarraysInRecordsReader.m
+++ b/matlab/generated/+test_model/+binary/SubarraysInRecordsReader.m
@@ -8,8 +8,12 @@ classdef SubarraysInRecordsReader < yardl.binary.BinaryProtocolReader & test_mod
   end
 
   methods
-    function self = SubarraysInRecordsReader(filename)
-      self@test_model.SubarraysInRecordsReaderBase();
+    function self = SubarraysInRecordsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.SubarraysInRecordsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.SubarraysInRecordsReaderBase.schema);
       self.with_fixed_subarrays_serializer = yardl.binary.DynamicNDArraySerializer(test_model.binary.RecordWithFixedCollectionsSerializer());
       self.with_vlen_subarrays_serializer = yardl.binary.DynamicNDArraySerializer(test_model.binary.RecordWithVlenCollectionsSerializer());

--- a/matlab/generated/+test_model/+binary/SubarraysReader.m
+++ b/matlab/generated/+test_model/+binary/SubarraysReader.m
@@ -15,8 +15,12 @@ classdef SubarraysReader < yardl.binary.BinaryProtocolReader & test_model.Subarr
   end
 
   methods
-    function self = SubarraysReader(filename)
-      self@test_model.SubarraysReaderBase();
+    function self = SubarraysReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.SubarraysReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.SubarraysReaderBase.schema);
       self.dynamic_with_fixed_int_subarray_serializer = yardl.binary.DynamicNDArraySerializer(yardl.binary.FixedNDArraySerializer(yardl.binary.Int32Serializer, [3]));
       self.dynamic_with_fixed_float_subarray_serializer = yardl.binary.DynamicNDArraySerializer(yardl.binary.FixedNDArraySerializer(yardl.binary.Float32Serializer, [3]));

--- a/matlab/generated/+test_model/+binary/UnionsReader.m
+++ b/matlab/generated/+test_model/+binary/UnionsReader.m
@@ -10,8 +10,12 @@ classdef UnionsReader < yardl.binary.BinaryProtocolReader & test_model.UnionsRea
   end
 
   methods
-    function self = UnionsReader(filename)
-      self@test_model.UnionsReaderBase();
+    function self = UnionsReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.UnionsReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.UnionsReaderBase.schema);
       self.int_or_simple_record_serializer = yardl.binary.UnionSerializer('test_model.Int32OrSimpleRecord', {yardl.binary.Int32Serializer, test_model.binary.SimpleRecordSerializer()}, {@test_model.Int32OrSimpleRecord.Int32, @test_model.Int32OrSimpleRecord.SimpleRecord});
       self.int_or_record_with_vlens_serializer = yardl.binary.UnionSerializer('test_model.Int32OrRecordWithVlens', {yardl.binary.Int32Serializer, test_model.binary.RecordWithVlensSerializer()}, {@test_model.Int32OrRecordWithVlens.Int32, @test_model.Int32OrRecordWithVlens.RecordWithVlens});

--- a/matlab/generated/+test_model/+binary/VlensReader.m
+++ b/matlab/generated/+test_model/+binary/VlensReader.m
@@ -10,8 +10,12 @@ classdef VlensReader < yardl.binary.BinaryProtocolReader & test_model.VlensReade
   end
 
   methods
-    function self = VlensReader(filename)
-      self@test_model.VlensReaderBase();
+    function self = VlensReader(filename, options)
+      arguments
+        filename (1,1) string
+        options.skip_completed_check (1,1) logical = false
+      end
+      self@test_model.VlensReaderBase(skip_completed_check=options.skip_completed_check);
       self@yardl.binary.BinaryProtocolReader(filename, test_model.VlensReaderBase.schema);
       self.int_vector_serializer = yardl.binary.VectorSerializer(yardl.binary.Int32Serializer);
       self.complex_vector_serializer = yardl.binary.VectorSerializer(yardl.binary.Complexfloat32Serializer);

--- a/matlab/generated/+test_model/AdvancedGenericsReaderBase.m
+++ b/matlab/generated/+test_model/AdvancedGenericsReaderBase.m
@@ -3,16 +3,21 @@
 classdef AdvancedGenericsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = AdvancedGenericsReaderBase()
+    function self = AdvancedGenericsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 5
+      if ~self.skip_completed_check_ && self.state_ ~= 5
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/AliasesReaderBase.m
+++ b/matlab/generated/+test_model/AliasesReaderBase.m
@@ -3,16 +3,21 @@
 classdef AliasesReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = AliasesReaderBase()
+    function self = AliasesReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 11
+      if ~self.skip_completed_check_ && self.state_ ~= 11
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/BenchmarkFloat256x256ReaderBase.m
+++ b/matlab/generated/+test_model/BenchmarkFloat256x256ReaderBase.m
@@ -3,16 +3,21 @@
 classdef BenchmarkFloat256x256ReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = BenchmarkFloat256x256ReaderBase()
+    function self = BenchmarkFloat256x256ReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/BenchmarkFloatVlenReaderBase.m
+++ b/matlab/generated/+test_model/BenchmarkFloatVlenReaderBase.m
@@ -3,16 +3,21 @@
 classdef BenchmarkFloatVlenReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = BenchmarkFloatVlenReaderBase()
+    function self = BenchmarkFloatVlenReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/BenchmarkInt256x256ReaderBase.m
+++ b/matlab/generated/+test_model/BenchmarkInt256x256ReaderBase.m
@@ -3,16 +3,21 @@
 classdef BenchmarkInt256x256ReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = BenchmarkInt256x256ReaderBase()
+    function self = BenchmarkInt256x256ReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/BenchmarkSimpleMrdReaderBase.m
+++ b/matlab/generated/+test_model/BenchmarkSimpleMrdReaderBase.m
@@ -3,16 +3,21 @@
 classdef BenchmarkSimpleMrdReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = BenchmarkSimpleMrdReaderBase()
+    function self = BenchmarkSimpleMrdReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/BenchmarkSmallRecordReaderBase.m
+++ b/matlab/generated/+test_model/BenchmarkSmallRecordReaderBase.m
@@ -3,16 +3,21 @@
 classdef BenchmarkSmallRecordReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = BenchmarkSmallRecordReaderBase()
+    function self = BenchmarkSmallRecordReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/BenchmarkSmallRecordWithOptionalsReaderBase.m
+++ b/matlab/generated/+test_model/BenchmarkSmallRecordWithOptionalsReaderBase.m
@@ -3,16 +3,21 @@
 classdef BenchmarkSmallRecordWithOptionalsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = BenchmarkSmallRecordWithOptionalsReaderBase()
+    function self = BenchmarkSmallRecordWithOptionalsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/ComplexArraysReaderBase.m
+++ b/matlab/generated/+test_model/ComplexArraysReaderBase.m
@@ -3,16 +3,21 @@
 classdef ComplexArraysReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = ComplexArraysReaderBase()
+    function self = ComplexArraysReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 2
+      if ~self.skip_completed_check_ && self.state_ ~= 2
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/DynamicNDArraysReaderBase.m
+++ b/matlab/generated/+test_model/DynamicNDArraysReaderBase.m
@@ -3,16 +3,21 @@
 classdef DynamicNDArraysReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = DynamicNDArraysReaderBase()
+    function self = DynamicNDArraysReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 4
+      if ~self.skip_completed_check_ && self.state_ ~= 4
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/EnumsReaderBase.m
+++ b/matlab/generated/+test_model/EnumsReaderBase.m
@@ -3,16 +3,21 @@
 classdef EnumsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = EnumsReaderBase()
+    function self = EnumsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 4
+      if ~self.skip_completed_check_ && self.state_ ~= 4
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/FixedArraysReaderBase.m
+++ b/matlab/generated/+test_model/FixedArraysReaderBase.m
@@ -3,16 +3,21 @@
 classdef FixedArraysReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = FixedArraysReaderBase()
+    function self = FixedArraysReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 5
+      if ~self.skip_completed_check_ && self.state_ ~= 5
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/FixedVectorsReaderBase.m
+++ b/matlab/generated/+test_model/FixedVectorsReaderBase.m
@@ -3,16 +3,21 @@
 classdef FixedVectorsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = FixedVectorsReaderBase()
+    function self = FixedVectorsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 4
+      if ~self.skip_completed_check_ && self.state_ ~= 4
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/FlagsReaderBase.m
+++ b/matlab/generated/+test_model/FlagsReaderBase.m
@@ -3,16 +3,21 @@
 classdef FlagsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = FlagsReaderBase()
+    function self = FlagsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 2
+      if ~self.skip_completed_check_ && self.state_ ~= 2
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/MapsReaderBase.m
+++ b/matlab/generated/+test_model/MapsReaderBase.m
@@ -3,16 +3,21 @@
 classdef MapsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = MapsReaderBase()
+    function self = MapsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 5
+      if ~self.skip_completed_check_ && self.state_ ~= 5
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/MultiDArraysReaderBase.m
+++ b/matlab/generated/+test_model/MultiDArraysReaderBase.m
@@ -3,16 +3,21 @@
 classdef MultiDArraysReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = MultiDArraysReaderBase()
+    function self = MultiDArraysReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 2
+      if ~self.skip_completed_check_ && self.state_ ~= 2
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/NDArraysReaderBase.m
+++ b/matlab/generated/+test_model/NDArraysReaderBase.m
@@ -3,16 +3,21 @@
 classdef NDArraysReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = NDArraysReaderBase()
+    function self = NDArraysReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 5
+      if ~self.skip_completed_check_ && self.state_ ~= 5
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/NDArraysSingleDimensionReaderBase.m
+++ b/matlab/generated/+test_model/NDArraysSingleDimensionReaderBase.m
@@ -3,16 +3,21 @@
 classdef NDArraysSingleDimensionReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = NDArraysSingleDimensionReaderBase()
+    function self = NDArraysSingleDimensionReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 4
+      if ~self.skip_completed_check_ && self.state_ ~= 4
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/NestedRecordsReaderBase.m
+++ b/matlab/generated/+test_model/NestedRecordsReaderBase.m
@@ -3,16 +3,21 @@
 classdef NestedRecordsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = NestedRecordsReaderBase()
+    function self = NestedRecordsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/OptionalVectorsReaderBase.m
+++ b/matlab/generated/+test_model/OptionalVectorsReaderBase.m
@@ -3,16 +3,21 @@
 classdef OptionalVectorsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = OptionalVectorsReaderBase()
+    function self = OptionalVectorsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/ProtocolWithComputedFieldsReaderBase.m
+++ b/matlab/generated/+test_model/ProtocolWithComputedFieldsReaderBase.m
@@ -3,16 +3,21 @@
 classdef ProtocolWithComputedFieldsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = ProtocolWithComputedFieldsReaderBase()
+    function self = ProtocolWithComputedFieldsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/ProtocolWithKeywordStepsReaderBase.m
+++ b/matlab/generated/+test_model/ProtocolWithKeywordStepsReaderBase.m
@@ -3,16 +3,21 @@
 classdef ProtocolWithKeywordStepsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = ProtocolWithKeywordStepsReaderBase()
+    function self = ProtocolWithKeywordStepsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 2
+      if ~self.skip_completed_check_ && self.state_ ~= 2
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/ProtocolWithOptionalDateReaderBase.m
+++ b/matlab/generated/+test_model/ProtocolWithOptionalDateReaderBase.m
@@ -3,16 +3,21 @@
 classdef ProtocolWithOptionalDateReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = ProtocolWithOptionalDateReaderBase()
+    function self = ProtocolWithOptionalDateReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 1
+      if ~self.skip_completed_check_ && self.state_ ~= 1
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/ScalarOptionalsReaderBase.m
+++ b/matlab/generated/+test_model/ScalarOptionalsReaderBase.m
@@ -3,16 +3,21 @@
 classdef ScalarOptionalsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = ScalarOptionalsReaderBase()
+    function self = ScalarOptionalsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 4
+      if ~self.skip_completed_check_ && self.state_ ~= 4
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/ScalarsReaderBase.m
+++ b/matlab/generated/+test_model/ScalarsReaderBase.m
@@ -3,16 +3,21 @@
 classdef ScalarsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = ScalarsReaderBase()
+    function self = ScalarsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 2
+      if ~self.skip_completed_check_ && self.state_ ~= 2
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/SimpleGenericsReaderBase.m
+++ b/matlab/generated/+test_model/SimpleGenericsReaderBase.m
@@ -3,16 +3,21 @@
 classdef SimpleGenericsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = SimpleGenericsReaderBase()
+    function self = SimpleGenericsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 9
+      if ~self.skip_completed_check_ && self.state_ ~= 9
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/StateTestReaderBase.m
+++ b/matlab/generated/+test_model/StateTestReaderBase.m
@@ -3,16 +3,21 @@
 classdef StateTestReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = StateTestReaderBase()
+    function self = StateTestReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 3
+      if ~self.skip_completed_check_ && self.state_ ~= 3
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/StreamsOfAliasedUnionsReaderBase.m
+++ b/matlab/generated/+test_model/StreamsOfAliasedUnionsReaderBase.m
@@ -3,16 +3,21 @@
 classdef StreamsOfAliasedUnionsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = StreamsOfAliasedUnionsReaderBase()
+    function self = StreamsOfAliasedUnionsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 2
+      if ~self.skip_completed_check_ && self.state_ ~= 2
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/StreamsOfUnionsReaderBase.m
+++ b/matlab/generated/+test_model/StreamsOfUnionsReaderBase.m
@@ -3,16 +3,21 @@
 classdef StreamsOfUnionsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = StreamsOfUnionsReaderBase()
+    function self = StreamsOfUnionsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 3
+      if ~self.skip_completed_check_ && self.state_ ~= 3
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/StreamsReaderBase.m
+++ b/matlab/generated/+test_model/StreamsReaderBase.m
@@ -3,16 +3,21 @@
 classdef StreamsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = StreamsReaderBase()
+    function self = StreamsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 4
+      if ~self.skip_completed_check_ && self.state_ ~= 4
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/StringsReaderBase.m
+++ b/matlab/generated/+test_model/StringsReaderBase.m
@@ -3,16 +3,21 @@
 classdef StringsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = StringsReaderBase()
+    function self = StringsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 2
+      if ~self.skip_completed_check_ && self.state_ ~= 2
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/SubarraysInRecordsReaderBase.m
+++ b/matlab/generated/+test_model/SubarraysInRecordsReaderBase.m
@@ -3,16 +3,21 @@
 classdef SubarraysInRecordsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = SubarraysInRecordsReaderBase()
+    function self = SubarraysInRecordsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 2
+      if ~self.skip_completed_check_ && self.state_ ~= 2
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/SubarraysReaderBase.m
+++ b/matlab/generated/+test_model/SubarraysReaderBase.m
@@ -3,16 +3,21 @@
 classdef SubarraysReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = SubarraysReaderBase()
+    function self = SubarraysReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 9
+      if ~self.skip_completed_check_ && self.state_ ~= 9
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/UnionsReaderBase.m
+++ b/matlab/generated/+test_model/UnionsReaderBase.m
@@ -3,16 +3,21 @@
 classdef UnionsReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = UnionsReaderBase()
+    function self = UnionsReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 4
+      if ~self.skip_completed_check_ && self.state_ ~= 4
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/generated/+test_model/VlensReaderBase.m
+++ b/matlab/generated/+test_model/VlensReaderBase.m
@@ -3,16 +3,21 @@
 classdef VlensReaderBase < handle
   properties (Access=protected)
     state_
+    skip_completed_check_
   end
 
   methods
-    function self = VlensReaderBase()
+    function self = VlensReaderBase(options)
+      arguments
+        options.skip_completed_check (1,1) logical = false
+      end
       self.state_ = 0;
+      self.skip_completed_check_ = options.skip_completed_check;
     end
 
     function close(self)
       self.close_();
-      if self.state_ ~= 4
+      if ~self.skip_completed_check_ && self.state_ ~= 4
         expected_method = self.state_to_method_name_(self.state_);
         throw(yardl.ProtocolError("Protocol reader closed before all data was consumed. Expected call to '%s'.", expected_method));
       end

--- a/matlab/test/PartialReadTest.m
+++ b/matlab/test/PartialReadTest.m
@@ -1,0 +1,51 @@
+% Copyright (c) Microsoft Corporation.
+% Licensed under the MIT License.
+
+classdef PartialReadTest < matlab.unittest.TestCase
+
+    methods (Static)
+        function filename = generateStream()
+            filename = tempname();
+            w = test_model.binary.StateTestWriter(filename);
+            w.write_an_int(42);
+            w.write_a_stream([1, 2, 3, 4, 5]);
+            w.end_a_stream();
+            w.write_another_int(153);
+            w.close();
+        end
+    end
+
+    methods (Test)
+
+        function testSkipSteps(testCase)
+            filename = PartialReadTest.generateStream();
+            r = test_model.binary.StateTestReader(filename, skip_completed_check=true);
+            r.read_an_int();
+            r.close();
+
+            r = test_model.binary.StateTestReader(filename, skip_completed_check=true);
+            r.read_an_int();
+            while r.has_a_stream()
+                item = r.read_a_stream();
+            end
+            r.close();
+        end
+
+        function testSkipStreamItems(testCase)
+            filename = PartialReadTest.generateStream();
+            r = test_model.binary.StateTestReader(filename, skip_completed_check=true);
+            r.read_an_int();
+            count = 0;
+            while r.has_a_stream()
+                item = r.read_a_stream();
+                % Skip remaining stream items
+                if count == 2
+                    break;
+                end
+                count = count + 1;
+            end
+            r.close();
+        end
+
+    end
+end

--- a/python/test_model/binary.py
+++ b/python/test_model/binary.py
@@ -35,8 +35,8 @@ class BinaryBenchmarkFloat256x256Reader(_binary.BinaryProtocolReader, BenchmarkF
     """Binary writer for the BenchmarkFloat256x256 protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        BenchmarkFloat256x256ReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        BenchmarkFloat256x256ReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, BenchmarkFloat256x256ReaderBase.schema)
 
     def _read_float256x256(self) -> collections.abc.Iterable[npt.NDArray[np.float32]]:
@@ -58,8 +58,8 @@ class BinaryBenchmarkInt256x256Reader(_binary.BinaryProtocolReader, BenchmarkInt
     """Binary writer for the BenchmarkInt256x256 protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        BenchmarkInt256x256ReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        BenchmarkInt256x256ReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, BenchmarkInt256x256ReaderBase.schema)
 
     def _read_int256x256(self) -> collections.abc.Iterable[npt.NDArray[np.int32]]:
@@ -81,8 +81,8 @@ class BinaryBenchmarkFloatVlenReader(_binary.BinaryProtocolReader, BenchmarkFloa
     """Binary writer for the BenchmarkFloatVlen protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        BenchmarkFloatVlenReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        BenchmarkFloatVlenReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, BenchmarkFloatVlenReaderBase.schema)
 
     def _read_float_array(self) -> collections.abc.Iterable[npt.NDArray[np.float32]]:
@@ -104,8 +104,8 @@ class BinaryBenchmarkSmallRecordReader(_binary.BinaryProtocolReader, BenchmarkSm
     """Binary writer for the BenchmarkSmallRecord protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        BenchmarkSmallRecordReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        BenchmarkSmallRecordReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, BenchmarkSmallRecordReaderBase.schema)
 
     def _read_small_record(self) -> collections.abc.Iterable[SmallBenchmarkRecord]:
@@ -127,8 +127,8 @@ class BinaryBenchmarkSmallRecordWithOptionalsReader(_binary.BinaryProtocolReader
     """Binary writer for the BenchmarkSmallRecordWithOptionals protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        BenchmarkSmallRecordWithOptionalsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        BenchmarkSmallRecordWithOptionalsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, BenchmarkSmallRecordWithOptionalsReaderBase.schema)
 
     def _read_small_record(self) -> collections.abc.Iterable[SimpleEncodingCounters]:
@@ -150,8 +150,8 @@ class BinaryBenchmarkSimpleMrdReader(_binary.BinaryProtocolReader, BenchmarkSimp
     """Binary writer for the BenchmarkSimpleMrd protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        BenchmarkSimpleMrdReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        BenchmarkSimpleMrdReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, BenchmarkSimpleMrdReaderBase.schema)
 
     def _read_data(self) -> collections.abc.Iterable[AcquisitionOrImage]:
@@ -176,8 +176,8 @@ class BinaryScalarsReader(_binary.BinaryProtocolReader, ScalarsReaderBase):
     """Binary writer for the Scalars protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        ScalarsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        ScalarsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, ScalarsReaderBase.schema)
 
     def _read_int32(self) -> yardl.Int32:
@@ -211,8 +211,8 @@ class BinaryScalarOptionalsReader(_binary.BinaryProtocolReader, ScalarOptionalsR
     """Binary writer for the ScalarOptionals protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        ScalarOptionalsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        ScalarOptionalsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, ScalarOptionalsReaderBase.schema)
 
     def _read_optional_int(self) -> typing.Optional[yardl.Int32]:
@@ -243,8 +243,8 @@ class BinaryNestedRecordsReader(_binary.BinaryProtocolReader, NestedRecordsReade
     """Binary writer for the NestedRecords protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        NestedRecordsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        NestedRecordsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, NestedRecordsReaderBase.schema)
 
     def _read_tuple_with_records(self) -> TupleWithRecords:
@@ -275,8 +275,8 @@ class BinaryVlensReader(_binary.BinaryProtocolReader, VlensReaderBase):
     """Binary writer for the Vlens protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        VlensReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        VlensReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, VlensReaderBase.schema)
 
     def _read_int_vector(self) -> list[yardl.Int32]:
@@ -310,8 +310,8 @@ class BinaryStringsReader(_binary.BinaryProtocolReader, StringsReaderBase):
     """Binary writer for the Strings protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        StringsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        StringsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, StringsReaderBase.schema)
 
     def _read_single_string(self) -> str:
@@ -336,8 +336,8 @@ class BinaryOptionalVectorsReader(_binary.BinaryProtocolReader, OptionalVectorsR
     """Binary writer for the OptionalVectors protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        OptionalVectorsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        OptionalVectorsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, OptionalVectorsReaderBase.schema)
 
     def _read_record_with_optional_vector(self) -> RecordWithOptionalVector:
@@ -368,8 +368,8 @@ class BinaryFixedVectorsReader(_binary.BinaryProtocolReader, FixedVectorsReaderB
     """Binary writer for the FixedVectors protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        FixedVectorsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        FixedVectorsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, FixedVectorsReaderBase.schema)
 
     def _read_fixed_int_vector(self) -> list[yardl.Int32]:
@@ -409,8 +409,8 @@ class BinaryStreamsReader(_binary.BinaryProtocolReader, StreamsReaderBase):
     """Binary writer for the Streams protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        StreamsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        StreamsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, StreamsReaderBase.schema)
 
     def _read_int_data(self) -> collections.abc.Iterable[yardl.Int32]:
@@ -453,8 +453,8 @@ class BinaryFixedArraysReader(_binary.BinaryProtocolReader, FixedArraysReaderBas
     """Binary writer for the FixedArrays protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        FixedArraysReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        FixedArraysReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, FixedArraysReaderBase.schema)
 
     def _read_ints(self) -> npt.NDArray[np.int32]:
@@ -512,8 +512,8 @@ class BinarySubarraysReader(_binary.BinaryProtocolReader, SubarraysReaderBase):
     """Binary writer for the Subarrays protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        SubarraysReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        SubarraysReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, SubarraysReaderBase.schema)
 
     def _read_dynamic_with_fixed_int_subarray(self) -> npt.NDArray[np.int32]:
@@ -562,8 +562,8 @@ class BinarySubarraysInRecordsReader(_binary.BinaryProtocolReader, SubarraysInRe
     """Binary writer for the SubarraysInRecords protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        SubarraysInRecordsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        SubarraysInRecordsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, SubarraysInRecordsReaderBase.schema)
 
     def _read_with_fixed_subarrays(self) -> npt.NDArray[np.void]:
@@ -600,8 +600,8 @@ class BinaryNDArraysReader(_binary.BinaryProtocolReader, NDArraysReaderBase):
     """Binary writer for the NDArrays protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        NDArraysReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        NDArraysReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, NDArraysReaderBase.schema)
 
     def _read_ints(self) -> npt.NDArray[np.int32]:
@@ -644,8 +644,8 @@ class BinaryNDArraysSingleDimensionReader(_binary.BinaryProtocolReader, NDArrays
     """Binary writer for the NDArraysSingleDimension protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        NDArraysSingleDimensionReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        NDArraysSingleDimensionReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, NDArraysSingleDimensionReaderBase.schema)
 
     def _read_ints(self) -> npt.NDArray[np.int32]:
@@ -685,8 +685,8 @@ class BinaryDynamicNDArraysReader(_binary.BinaryProtocolReader, DynamicNDArraysR
     """Binary writer for the DynamicNDArrays protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        DynamicNDArraysReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        DynamicNDArraysReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, DynamicNDArraysReaderBase.schema)
 
     def _read_ints(self) -> npt.NDArray[np.int32]:
@@ -720,8 +720,8 @@ class BinaryMultiDArraysReader(_binary.BinaryProtocolReader, MultiDArraysReaderB
     """Binary writer for the MultiDArrays protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        MultiDArraysReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        MultiDArraysReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, MultiDArraysReaderBase.schema)
 
     def _read_images(self) -> collections.abc.Iterable[npt.NDArray[np.float32]]:
@@ -749,8 +749,8 @@ class BinaryComplexArraysReader(_binary.BinaryProtocolReader, ComplexArraysReade
     """Binary writer for the ComplexArrays protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        ComplexArraysReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        ComplexArraysReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, ComplexArraysReaderBase.schema)
 
     def _read_floats(self) -> npt.NDArray[np.complex64]:
@@ -787,8 +787,8 @@ class BinaryMapsReader(_binary.BinaryProtocolReader, MapsReaderBase):
     """Binary writer for the Maps protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        MapsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        MapsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, MapsReaderBase.schema)
 
     def _read_string_to_int(self) -> dict[str, yardl.Int32]:
@@ -831,8 +831,8 @@ class BinaryUnionsReader(_binary.BinaryProtocolReader, UnionsReaderBase):
     """Binary writer for the Unions protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        UnionsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        UnionsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, UnionsReaderBase.schema)
 
     def _read_int_or_simple_record(self) -> Int32OrSimpleRecord:
@@ -869,8 +869,8 @@ class BinaryStreamsOfUnionsReader(_binary.BinaryProtocolReader, StreamsOfUnionsR
     """Binary writer for the StreamsOfUnions protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        StreamsOfUnionsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        StreamsOfUnionsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, StreamsOfUnionsReaderBase.schema)
 
     def _read_int_or_simple_record(self) -> collections.abc.Iterable[Int32OrSimpleRecord]:
@@ -907,8 +907,8 @@ class BinaryEnumsReader(_binary.BinaryProtocolReader, EnumsReaderBase):
     """Binary writer for the Enums protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        EnumsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        EnumsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, EnumsReaderBase.schema)
 
     def _read_single(self) -> Fruits:
@@ -942,8 +942,8 @@ class BinaryFlagsReader(_binary.BinaryProtocolReader, FlagsReaderBase):
     """Binary writer for the Flags protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        FlagsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        FlagsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, FlagsReaderBase.schema)
 
     def _read_days(self) -> collections.abc.Iterable[DaysOfWeek]:
@@ -974,8 +974,8 @@ class BinaryStateTestReader(_binary.BinaryProtocolReader, StateTestReaderBase):
     """Binary writer for the StateTest protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        StateTestReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        StateTestReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, StateTestReaderBase.schema)
 
     def _read_an_int(self) -> yardl.Int32:
@@ -1027,8 +1027,8 @@ class BinarySimpleGenericsReader(_binary.BinaryProtocolReader, SimpleGenericsRea
     """Binary writer for the SimpleGenerics protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        SimpleGenericsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        SimpleGenericsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, SimpleGenericsReaderBase.schema)
 
     def _read_float_image(self) -> image.FloatImage:
@@ -1086,8 +1086,8 @@ class BinaryAdvancedGenericsReader(_binary.BinaryProtocolReader, AdvancedGeneric
     """Binary writer for the AdvancedGenerics protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        AdvancedGenericsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        AdvancedGenericsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, AdvancedGenericsReaderBase.schema)
 
     def _read_float_image_image(self) -> Image[np.object_]:
@@ -1151,8 +1151,8 @@ class BinaryAliasesReader(_binary.BinaryProtocolReader, AliasesReaderBase):
     """Binary writer for the Aliases protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        AliasesReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        AliasesReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, AliasesReaderBase.schema)
 
     def _read_aliased_string(self) -> AliasedString:
@@ -1207,8 +1207,8 @@ class BinaryStreamsOfAliasedUnionsReader(_binary.BinaryProtocolReader, StreamsOf
     """Binary writer for the StreamsOfAliasedUnions protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        StreamsOfAliasedUnionsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        StreamsOfAliasedUnionsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, StreamsOfAliasedUnionsReaderBase.schema)
 
     def _read_int_or_simple_record(self) -> collections.abc.Iterable[AliasedIntOrSimpleRecord]:
@@ -1233,8 +1233,8 @@ class BinaryProtocolWithComputedFieldsReader(_binary.BinaryProtocolReader, Proto
     """Binary writer for the ProtocolWithComputedFields protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        ProtocolWithComputedFieldsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        ProtocolWithComputedFieldsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, ProtocolWithComputedFieldsReaderBase.schema)
 
     def _read_record_with_computed_fields(self) -> RecordWithComputedFields:
@@ -1259,8 +1259,8 @@ class BinaryProtocolWithKeywordStepsReader(_binary.BinaryProtocolReader, Protoco
     """Binary writer for the ProtocolWithKeywordSteps protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        ProtocolWithKeywordStepsReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        ProtocolWithKeywordStepsReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, ProtocolWithKeywordStepsReaderBase.schema)
 
     def _read_int(self) -> collections.abc.Iterable[RecordWithKeywordFields]:
@@ -1285,8 +1285,8 @@ class BinaryProtocolWithOptionalDateReader(_binary.BinaryProtocolReader, Protoco
     """Binary writer for the ProtocolWithOptionalDate protocol."""
 
 
-    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:
-        ProtocolWithOptionalDateReaderBase.__init__(self)
+    def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:
+        ProtocolWithOptionalDateReaderBase.__init__(self, skip_completed_check)
         _binary.BinaryProtocolReader.__init__(self, stream, ProtocolWithOptionalDateReaderBase.schema)
 
     def _read_record(self) -> typing.Optional[RecordWithOptionalDate]:

--- a/python/test_model/protocols.py
+++ b/python/test_model/protocols.py
@@ -80,12 +80,13 @@ class BenchmarkFloat256x256ReaderBase(abc.ABC):
     """Abstract reader for the BenchmarkFloat256x256 protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -212,12 +213,13 @@ class BenchmarkInt256x256ReaderBase(abc.ABC):
     """Abstract reader for the BenchmarkInt256x256 protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -344,12 +346,13 @@ class BenchmarkFloatVlenReaderBase(abc.ABC):
     """Abstract reader for the BenchmarkFloatVlen protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -476,12 +479,13 @@ class BenchmarkSmallRecordReaderBase(abc.ABC):
     """Abstract reader for the BenchmarkSmallRecord protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -608,12 +612,13 @@ class BenchmarkSmallRecordWithOptionalsReaderBase(abc.ABC):
     """Abstract reader for the BenchmarkSmallRecordWithOptionals protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -740,12 +745,13 @@ class BenchmarkSimpleMrdReaderBase(abc.ABC):
     """Abstract reader for the BenchmarkSimpleMrd protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -881,12 +887,13 @@ class ScalarsReaderBase(abc.ABC):
     """Abstract reader for the Scalars protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 4:
+        if not self._skip_completed_check and self._state != 4:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -1069,12 +1076,13 @@ class ScalarOptionalsReaderBase(abc.ABC):
     """Abstract reader for the ScalarOptionals protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 8:
+        if not self._skip_completed_check and self._state != 8:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -1246,12 +1254,13 @@ class NestedRecordsReaderBase(abc.ABC):
     """Abstract reader for the NestedRecords protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -1417,12 +1426,13 @@ class VlensReaderBase(abc.ABC):
     """Abstract reader for the Vlens protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 8:
+        if not self._skip_completed_check and self._state != 8:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -1609,12 +1619,13 @@ class StringsReaderBase(abc.ABC):
     """Abstract reader for the Strings protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 4:
+        if not self._skip_completed_check and self._state != 4:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -1752,12 +1763,13 @@ class OptionalVectorsReaderBase(abc.ABC):
     """Abstract reader for the OptionalVectors protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -1923,12 +1935,13 @@ class FixedVectorsReaderBase(abc.ABC):
     """Abstract reader for the FixedVectors protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 8:
+        if not self._skip_completed_check and self._state != 8:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -2160,12 +2173,13 @@ class StreamsReaderBase(abc.ABC):
     """Abstract reader for the Streams protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 8:
+        if not self._skip_completed_check and self._state != 8:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -2397,12 +2411,13 @@ class FixedArraysReaderBase(abc.ABC):
     """Abstract reader for the FixedArrays protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 10:
+        if not self._skip_completed_check and self._state != 10:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -2711,12 +2726,13 @@ class SubarraysReaderBase(abc.ABC):
     """Abstract reader for the Subarrays protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 18:
+        if not self._skip_completed_check and self._state != 18:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -2988,12 +3004,13 @@ class SubarraysInRecordsReaderBase(abc.ABC):
     """Abstract reader for the SubarraysInRecords protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 4:
+        if not self._skip_completed_check and self._state != 4:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -3191,12 +3208,13 @@ class NDArraysReaderBase(abc.ABC):
     """Abstract reader for the NDArrays protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 10:
+        if not self._skip_completed_check and self._state != 10:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -3430,12 +3448,13 @@ class NDArraysSingleDimensionReaderBase(abc.ABC):
     """Abstract reader for the NDArraysSingleDimension protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 8:
+        if not self._skip_completed_check and self._state != 8:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -3652,12 +3671,13 @@ class DynamicNDArraysReaderBase(abc.ABC):
     """Abstract reader for the DynamicNDArrays protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 8:
+        if not self._skip_completed_check and self._state != 8:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -3853,12 +3873,13 @@ class MultiDArraysReaderBase(abc.ABC):
     """Abstract reader for the MultiDArrays protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 4:
+        if not self._skip_completed_check and self._state != 4:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -4011,12 +4032,13 @@ class ComplexArraysReaderBase(abc.ABC):
     """Abstract reader for the ComplexArrays protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 4:
+        if not self._skip_completed_check and self._state != 4:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -4214,12 +4236,13 @@ class MapsReaderBase(abc.ABC):
     """Abstract reader for the Maps protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 10:
+        if not self._skip_completed_check and self._state != 10:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -4453,12 +4476,13 @@ class UnionsReaderBase(abc.ABC):
     """Abstract reader for the Unions protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 8:
+        if not self._skip_completed_check and self._state != 8:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -4672,12 +4696,13 @@ class StreamsOfUnionsReaderBase(abc.ABC):
     """Abstract reader for the StreamsOfUnions protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 6:
+        if not self._skip_completed_check and self._state != 6:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -4877,12 +4902,13 @@ class EnumsReaderBase(abc.ABC):
     """Abstract reader for the Enums protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 8:
+        if not self._skip_completed_check and self._state != 8:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -5078,12 +5104,13 @@ class FlagsReaderBase(abc.ABC):
     """Abstract reader for the Flags protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 4:
+        if not self._skip_completed_check and self._state != 4:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -5254,12 +5281,13 @@ class StateTestReaderBase(abc.ABC):
     """Abstract reader for the StateTest protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 6:
+        if not self._skip_completed_check and self._state != 6:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -5540,12 +5568,13 @@ class SimpleGenericsReaderBase(abc.ABC):
     """Abstract reader for the SimpleGenerics protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 18:
+        if not self._skip_completed_check and self._state != 18:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -5862,12 +5891,13 @@ class AdvancedGenericsReaderBase(abc.ABC):
     """Abstract reader for the AdvancedGenerics protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 10:
+        if not self._skip_completed_check and self._state != 10:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -6209,12 +6239,13 @@ class AliasesReaderBase(abc.ABC):
     """Abstract reader for the Aliases protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 22:
+        if not self._skip_completed_check and self._state != 22:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -6529,12 +6560,13 @@ class StreamsOfAliasedUnionsReaderBase(abc.ABC):
     """Abstract reader for the StreamsOfAliasedUnions protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 4:
+        if not self._skip_completed_check and self._state != 4:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -6672,12 +6704,13 @@ class ProtocolWithComputedFieldsReaderBase(abc.ABC):
     """Abstract reader for the ProtocolWithComputedFields protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -6816,12 +6849,13 @@ class ProtocolWithKeywordStepsReaderBase(abc.ABC):
     """Abstract reader for the ProtocolWithKeywordSteps protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 4:
+        if not self._skip_completed_check and self._state != 4:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")
@@ -6959,12 +6993,13 @@ class ProtocolWithOptionalDateReaderBase(abc.ABC):
     """Abstract reader for the ProtocolWithOptionalDate protocol."""
 
 
-    def __init__(self) -> None:
+    def __init__(self, skip_completed_check: bool = False) -> None:
+        self._skip_completed_check = skip_completed_check
         self._state = 0
 
     def close(self) -> None:
         self._close()
-        if self._state != 2:
+        if not self._skip_completed_check and self._state != 2:
             if self._state % 2 == 1:
                 previous_method = self._state_to_method_name(self._state - 1)
                 raise ProtocolError(f"Protocol reader closed before all data was consumed. The iterable returned by '{previous_method}' was not fully consumed.")

--- a/python/tests/test_partial_reads.py
+++ b/python/tests/test_partial_reads.py
@@ -1,0 +1,35 @@
+import io
+import test_model as tm
+
+
+def generate_stream():
+    b = io.BytesIO()
+    with tm.BinaryStateTestWriter(b) as w:
+        w.write_an_int(42)
+        w.write_a_stream([1, 2, 3, 4, 5])
+        w.write_another_int(153)
+    b.seek(0)
+    return b
+
+
+def test_skip_steps():
+    bytes = generate_stream()
+    with tm.BinaryStateTestReader(bytes, skip_completed_check=True) as r:
+        r.read_an_int()
+
+    bytes.seek(0)
+    with tm.BinaryStateTestReader(bytes, skip_completed_check=True) as r:
+        r.read_an_int()
+        for _ in r.read_a_stream():
+            pass
+        r.close()
+
+
+def test_skip_stream_items():
+    bytes = generate_stream()
+    with tm.BinaryStateTestReader(bytes, skip_completed_check=True) as r:
+        r.read_an_int()
+        stream = r.read_a_stream()
+        for i, _ in enumerate(stream):
+            if i == 2:
+                break

--- a/tooling/internal/cpp/binary/binary.go
+++ b/tooling/internal/cpp/binary/binary.go
@@ -126,18 +126,18 @@ func writeHeaderFile(env *dsl.Environment, options packaging.CppCodegenOptions) 
 			fmt.Fprintf(w, "class %s : public %s, yardl::binary::BinaryReader {\n", readerClassName, common.QualifiedAbstractReaderName(protocol))
 			w.Indented(func() {
 				fmt.Fprintln(w, "public:")
-				fmt.Fprintf(w, "%s(std::istream& stream)\n", readerClassName)
+				fmt.Fprintf(w, "%s(std::istream& stream, bool skip_completed_check=false)\n", readerClassName)
 				w.Indented(func() {
 					w.Indented(func() {
-						fmt.Fprintf(w, ": yardl::binary::BinaryReader(stream), version_(%s::VersionFromSchema(schema_read_)) {", common.QualifiedAbstractReaderName(protocol))
+						fmt.Fprintf(w, ": %s(skip_completed_check), yardl::binary::BinaryReader(stream), version_(%s::VersionFromSchema(schema_read_)) {", common.QualifiedAbstractReaderName(protocol), common.QualifiedAbstractReaderName(protocol))
 					})
 				})
 				w.WriteStringln("}\n")
 
-				fmt.Fprintf(w, "%s(std::string file_name)\n", readerClassName)
+				fmt.Fprintf(w, "%s(std::string file_name, bool skip_completed_check=false)\n", readerClassName)
 				w.Indented(func() {
 					w.Indented(func() {
-						fmt.Fprintf(w, ": yardl::binary::BinaryReader(file_name), version_(%s::VersionFromSchema(schema_read_)) {", common.QualifiedAbstractReaderName(protocol))
+						fmt.Fprintf(w, ": %s(skip_completed_check), yardl::binary::BinaryReader(file_name), version_(%s::VersionFromSchema(schema_read_)) {", common.QualifiedAbstractReaderName(protocol), common.QualifiedAbstractReaderName(protocol))
 					})
 				})
 				w.WriteStringln("}\n")
@@ -935,7 +935,11 @@ func writeProtocolMethods(w *formatting.IndentedWriter, p *dsl.ProtocolDefinitio
 
 	fmt.Fprintf(w, "void %s::CloseImpl() {\n", readerClassName)
 	w.Indented(func() {
-		w.WriteString("stream_.VerifyFinished();\n")
+		w.WriteStringln("if (!skip_completed_check_) {")
+		w.Indented(func() {
+			w.WriteString("stream_.VerifyFinished();\n")
+		})
+		w.WriteStringln("}")
 	})
 	w.WriteString("}\n\n")
 }

--- a/tooling/internal/matlab/binary/binary.go
+++ b/tooling/internal/matlab/binary/binary.go
@@ -99,9 +99,14 @@ func writeProtocolReader(fw *common.MatlabFileWriter, p *dsl.ProtocolDefinition,
 
 			w.WriteStringln("methods")
 			common.WriteBlockBody(w, func() {
-				fmt.Fprintf(w, "function self = %s(filename)\n", BinaryReaderName(p))
+				fmt.Fprintf(w, "function self = %s(filename, options)\n", BinaryReaderName(p))
 				common.WriteBlockBody(w, func() {
-					fmt.Fprintf(w, "self@%s();\n", abstractReaderName)
+					w.WriteStringln("arguments")
+					common.WriteBlockBody(w, func() {
+						w.WriteStringln("filename (1,1) string")
+						fmt.Fprintf(w, "options.skip_completed_check (1,1) logical = false\n")
+					})
+					fmt.Fprintf(w, "self@%s(skip_completed_check=options.skip_completed_check);\n", abstractReaderName)
 					fmt.Fprintf(w, "self@yardl.binary.BinaryProtocolReader(filename, %s.schema);\n", abstractReaderName)
 					for _, step := range p.Sequence {
 						fmt.Fprintf(w, "self.%s = %s;\n", serializerName(step), typeSerializer(step.Type, ns.Name, nil))

--- a/tooling/internal/python/binary/binary.go
+++ b/tooling/internal/python/binary/binary.go
@@ -186,9 +186,9 @@ func writeProtocols(w *formatting.IndentedWriter, ns *dsl.Namespace) {
 			common.WriteDocstringWithLeadingLine(w, fmt.Sprintf("Binary writer for the %s protocol.", p.Name), p.Comment)
 			w.WriteStringln("")
 
-			w.WriteStringln("def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str]) -> None:")
+			w.WriteStringln("def __init__(self, stream: typing.Union[io.BufferedReader, io.BytesIO, typing.BinaryIO, str], skip_completed_check: bool = False) -> None:")
 			w.Indented(func() {
-				fmt.Fprintf(w, "%s.__init__(self)\n", common.AbstractReaderName(p))
+				fmt.Fprintf(w, "%s.__init__(self, skip_completed_check)\n", common.AbstractReaderName(p))
 				fmt.Fprintf(w, "_binary.BinaryProtocolReader.__init__(self, stream, %s.schema)\n", common.AbstractReaderName(p))
 			})
 			w.WriteStringln("")

--- a/tooling/internal/python/protocols/protocols.go
+++ b/tooling/internal/python/protocols/protocols.go
@@ -211,8 +211,9 @@ func writeAbstractReader(w *formatting.IndentedWriter, p *dsl.ProtocolDefinition
 		w.WriteStringln("")
 
 		// init method
-		w.WriteStringln("def __init__(self) -> None:")
+		w.WriteStringln("def __init__(self, skip_completed_check: bool = False) -> None:")
 		w.Indented(func() {
+			w.WriteStringln("self._skip_completed_check = skip_completed_check")
 			w.WriteStringln("self._state = 0")
 		})
 		w.WriteStringln("")
@@ -221,7 +222,7 @@ func writeAbstractReader(w *formatting.IndentedWriter, p *dsl.ProtocolDefinition
 		w.WriteStringln("def close(self) -> None:")
 		w.Indented(func() {
 			w.WriteStringln("self._close()")
-			fmt.Fprintf(w, "if self._state != %d:\n", len(p.Sequence)*2)
+			fmt.Fprintf(w, "if not self._skip_completed_check and self._state != %d:\n", len(p.Sequence)*2)
 			w.Indented(func() {
 				w.WriteStringln(`if self._state % 2 == 1:
     previous_method = self._state_to_method_name(self._state - 1)


### PR DESCRIPTION
Allows users to consume only part of a protocol without any validation checks or exceptions.

Closes #183 