### PR TITLE
Add C++17 minimum requirement to generated library

### DIFF
--- a/cpp/evolution/v0/generated/CMakeLists.txt
+++ b/cpp/evolution/v0/generated/CMakeLists.txt
@@ -43,3 +43,4 @@ endif()
 
 add_library(evo_test_generated_v0 OBJECT ${EvoTest_GENERATED_SOURCES})
 target_link_libraries(evo_test_generated_v0 ${EvoTest_GENERATED_LINK_LIBRARIES})
+target_compile_features(evo_test_generated_v0 PUBLIC cxx_std_17)

--- a/cpp/evolution/v1/generated/CMakeLists.txt
+++ b/cpp/evolution/v1/generated/CMakeLists.txt
@@ -43,3 +43,4 @@ endif()
 
 add_library(evo_test_generated_v1 OBJECT ${EvoTest_GENERATED_SOURCES})
 target_link_libraries(evo_test_generated_v1 ${EvoTest_GENERATED_LINK_LIBRARIES})
+target_compile_features(evo_test_generated_v1 PUBLIC cxx_std_17)

--- a/cpp/evolution/v2/generated/CMakeLists.txt
+++ b/cpp/evolution/v2/generated/CMakeLists.txt
@@ -43,3 +43,4 @@ endif()
 
 add_library(evo_test_generated OBJECT ${EvoTest_GENERATED_SOURCES})
 target_link_libraries(evo_test_generated ${EvoTest_GENERATED_LINK_LIBRARIES})
+target_compile_features(evo_test_generated PUBLIC cxx_std_17)

--- a/cpp/test/generated/CMakeLists.txt
+++ b/cpp/test/generated/CMakeLists.txt
@@ -45,6 +45,7 @@ list(APPEND TestModel_GENERATED_SOURCES factories.cc translator_impl.cc)
 
 add_library(test_model_generated OBJECT ${TestModel_GENERATED_SOURCES})
 target_link_libraries(test_model_generated ${TestModel_GENERATED_LINK_LIBRARIES})
+target_compile_features(test_model_generated PUBLIC cxx_std_17)
 
 add_library(test_model_generated_mocks OBJECT mocks.cc)
 target_link_libraries(test_model_generated_mocks

--- a/tooling/internal/cpp/cmake.go
+++ b/tooling/internal/cpp/cmake.go
@@ -81,6 +81,7 @@ endif()
 
 	fmt.Fprintf(w, "add_library(%s OBJECT ${%s_SOURCES})\n", objectLibraryName, cmakePrefix)
 	fmt.Fprintf(w, "target_link_libraries(%s ${%s_LINK_LIBRARIES})\n", objectLibraryName, cmakePrefix)
+	fmt.Fprintf(w, "target_compile_features(%s PUBLIC cxx_std_17)\n", objectLibraryName)
 
 	if options.InternalGenerateMocks {
 		w.WriteStringln("")


### PR DESCRIPTION
Adding a minimum required C++ standard of C++17 to the generated C++ object library.

This ensures that `-std=c++17` or `-std=gnu++17` is added to the build flags when compiling and linking the generated code.

I don't think we need a CI test for this. I manually ran `just cpp_version=14`, which correctly sets `CMAKE_CXX_STANDARD` to C++14, but CMake will tell the compiler to use C++17 anyway.

Closes #261.